### PR TITLE
Use obsolete_pdbs_path when using mmseqs2

### DIFF
--- a/alphapulldown/create_individual_features.py
+++ b/alphapulldown/create_individual_features.py
@@ -95,7 +95,7 @@ def create_global_arguments(flags_dict):
         uniref30_database_path = FLAGS.uniref30_database_path
     flags_dict.update({"uniref30_database_path": uniref30_database_path})
 
-    if FLAGS.uniref90_database_path is None: 
+    if FLAGS.uniref90_database_path is None:
         uniref90_database_path = os.path.join(
             FLAGS.data_dir, "uniref90", "uniref90.fasta"
         )
@@ -210,7 +210,7 @@ def create_and_save_monomer_objects(m, pipeline, flags_dict,use_mmseqs2=False):
         )
         with output_meta_file(metadata_output_path) as meta_data_outfile:
             save_meta_data(flags_dict, meta_data_outfile)
-        
+
         if not use_mmseqs2:
             m.make_features(
                 pipeline,
@@ -224,7 +224,9 @@ def create_and_save_monomer_objects(m, pipeline, flags_dict,use_mmseqs2=False):
             pdb70_database_path=pdb70_database_path,
             template_mmcif_dir=template_mmcif_dir,
             max_template_date=FLAGS.max_template_date,
-            output_dir=FLAGS.output_dir)
+            output_dir=FLAGS.output_dir,
+            obsolete_pdbs_path=FLAGS.obsolete_pdbs_path
+            )
         pickle.dump(m, open(f"{FLAGS.output_dir}/{m.description}.pkl", "wb"))
         del m
 
@@ -241,7 +243,7 @@ def main(argv):
         Path(FLAGS.output_dir).mkdir(parents=True, exist_ok=True)
     except FileExistsError:
         logging.info("Multiple processes are trying to create the same folder now.")
-    
+
     flags_dict = FLAGS.flag_values_dict()
     create_global_arguments(flags_dict)
     if not FLAGS.use_mmseqs2:
@@ -262,7 +264,7 @@ def main(argv):
                 )
                 sys.exit()
     else:
-        
+
         pipeline=None
         uniprot_runner=None
         flags_dict=FLAGS.flag_values_dict()
@@ -275,9 +277,9 @@ def main(argv):
                 if curr_desc and not curr_desc.isspace():
                     curr_monomer = MonomericObject(curr_desc, curr_seq)
                     curr_monomer.uniprot_runner = uniprot_runner
-                    create_and_save_monomer_objects(curr_monomer, pipeline, 
+                    create_and_save_monomer_objects(curr_monomer, pipeline,
                     flags_dict,use_mmseqs2=FLAGS.use_mmseqs2)
-        
+
 
 if __name__ == "__main__":
     flags.mark_flags_as_required(

--- a/alphapulldown/objects.py
+++ b/alphapulldown/objects.py
@@ -157,9 +157,9 @@ class MonomericObject:
                 )
                 self.feature_dict.update(pairing_results)
 
-    def mk_template(self,a3m_lines,pdb70_database_path,template_mmcif_dir,query_sequence,max_template_date):
+    def mk_template(self,a3m_lines,pdb70_database_path,template_mmcif_dir,query_sequence,max_template_date, obsolete_pdbs_path=None):
         """
-        Overwrite ColabFold's original mk_template to incorporate max_template data argument 
+        Overwrite ColabFold's original mk_template to incorporate max_template data argument
         from the command line input.
         Modified from ColabFold: https://github.com/sokrypton/ColabFold
 
@@ -172,12 +172,12 @@ class MonomericObject:
         max_hits=20,
         kalign_binary_path="kalign",
         release_dates_path=None,
-        obsolete_pdbs_path=None,
+        obsolete_pdbs_path=obsolete_pdbs_path,
         )
         hhsearch_pdb70_runner = hhsearch.HHSearch(
         binary_path="hhsearch", databases=[f"{pdb70_database_path}"]
     )
-        
+
         hhsearch_result = hhsearch_pdb70_runner.query(a3m_lines)
         hhsearch_hits = pipeline.parsers.parse_hhr(hhsearch_result)
         templates_result = template_featuriser.get_templates(
@@ -186,15 +186,16 @@ class MonomericObject:
         return dict(templates_result.features)
 
     def make_mmseq_features(
-        self,DEFAULT_API_SERVER,pdb70_database_path,template_mmcif_dir,max_template_date,output_dir=None
+        self,DEFAULT_API_SERVER,pdb70_database_path,template_mmcif_dir,max_template_date,output_dir=None,obsolete_pdbs_path=None
     ):
         """
         A method to use mmseq_remote to calculate msa
         Modified from ColabFold: https://github.com/sokrypton/ColabFold
         """
-        
+
 
         logging.info("You chose to calculate MSA with mmseq2")
+        logging.info("Debug version")
         msa_mode = "MMseqs2 (UniRef+Environmental)"
         keep_existing_results=True
         result_dir = output_dir
@@ -220,7 +221,7 @@ class MonomericObject:
                     query_seqs_cardinality,
                     template_features,
                 ) = unserialize_msa(a3m_lines, self.sequence)
-                
+
         else:
             (
                 unpaired_msa,
@@ -247,11 +248,11 @@ class MonomericObject:
         # below will search against pdb70 database using hhsearch and create real template features
         logging.info("will search for templates in local template database")
         template_features = [self.mk_template(a3m_lines[0],
-        pdb70_database_path,template_mmcif_dir,query_sequence=self.sequence,max_template_date=max_template_date)]
+        pdb70_database_path,template_mmcif_dir,query_sequence=self.sequence,max_template_date=max_template_date, obsolete_pdbs_path=obsolete_pdbs_path)]
         self.feature_dict = build_monomer_feature(self.sequence,unpaired_msa[0],template_features[0])
-        
-        
-        # update feature_dict with 
+
+
+        # update feature_dict with
         valid_feats = msa_pairing.MSA_FEATURES + (
             "msa_species_identifiers",
             "msa_uniprot_accession_identifiers",


### PR DESCRIPTION
Hi,

I followed the example_1 using mmseqs2 mode and ended up in the following error (summarized)
```
I0322 22:14:01.857398 47047188311744 objects.py:208] input is example_1_sequences_shorter_feats/Q92901.a3m                                                                                                                            
...
I0322 22:15:22.197755 47047188311744 templates.py:878] Searching for template for: MSHRKFSAPRHGHLGFLPHKRSHRHRGKVKTWPRDDPSQPVHLTAFLGYKAGMTHTLREVHRPGLKISKREEVEAVTIVETPPLVVVGVVGYVATPRGLRSFKTIFAEHLSDECRRRFYKDWHKSKKKAFTKACKRWRDTDGKKQLQ
KDFAAMKKYCKVIRVIVHTQMKLLPFRQKKAHIMEIQLNGGTVAEKVAWAQARLEKQVPVHSVFSQSEVIDVIAVTKGRGVKGVTSRWHTKKLPRKTHKGLRKVACIGAWHPARVGCSIARAGQKGYHHRTELNKKIFRIGRGPHMEDGKLVKNNASTSYDVTAKSITPLGGFPHYGEVNNDFVMLKGCIAGTKKRVITLRKSLLVHHSRQAVENIELKFIDTTSKFGHG
RFQTAQEKRAFMGPQKKHLEKETPETSGDL         
...
Traceback (most recent call last):                                                                                                                                                                                                    
  File "/home/z44620n/anaconda3/envs/alphapulldown5/bin/create_individual_features.py", line 286, in <module>                                                                                                                         
    app.run(main)                                                                                                                                                                                                                     
  File "/home/z44620n/anaconda3/envs/alphapulldown5/lib/python3.8/site-packages/absl/app.py", line 308, in run                                                                                                                        
    _run_main(main, args)                                                                                                                                                                                                             
  File "/home/z44620n/anaconda3/envs/alphapulldown5/lib/python3.8/site-packages/absl/app.py", line 254, in _run_main                                                                                                                  
    sys.exit(main(argv))                                                                                                                                                                                                              
  File "/home/z44620n/anaconda3/envs/alphapulldown5/bin/create_individual_features.py", line 278, in main                                                                                                                             
    create_and_save_monomer_objects(curr_monomer, pipeline,                                                                                                                                                                           
  File "/home/z44620n/anaconda3/envs/alphapulldown5/bin/create_individual_features.py", line 223, in create_and_save_monomer_objects                                                                                                  
    m.make_mmseq_features(DEFAULT_API_SERVER=DEFAULT_API_SERVER,                                                                                                                                                                      
  File "/home/z44620n/anaconda3/envs/alphapulldown5/lib/python3.8/site-packages/alphapulldown/objects.py", line 249, in make_mmseq_features                                                                                           
    template_features = [self.mk_template(a3m_lines[0],                                                                                                                                                                               
  File "/home/z44620n/anaconda3/envs/alphapulldown5/lib/python3.8/site-packages/alphapulldown/objects.py", line 183, in mk_template                                                                                                   
    templates_result = template_featuriser.get_templates(                                                                                                                                                                             
  File "/home/z44620n/anaconda3/envs/alphapulldown5/lib/python3.8/site-packages/alphafold/data/templates.py", line 893, in get_templates                                                                                              
    result = _process_single_hit(                                                                                                                                                                                                     
  File "/home/z44620n/anaconda3/envs/alphapulldown5/lib/python3.8/site-packages/alphafold/data/templates.py", line 737, in _process_single_hit                                                                                        
    cif_string = _read_file(cif_path)                                                                                                                                                                                                 
  File "/home/z44620n/anaconda3/envs/alphapulldown5/lib/python3.8/site-packages/alphafold/data/templates.py", line 681, in _read_file                                                                                                 
    with open(path, 'r') as f:                                                                                                                                                                                                        
FileNotFoundError: [Errno 2] No such file or directory: '/beegfs/share/alphafold/db-v2.3/pdb_mmcif/mmcif_files/6ek0.cif'                                                             
```

The missing 6ek0 is an obsolete PDB entry which is superseded by 6qzp. This info is resistered in the pdb_mmcif/obsolete.dat.

But the current code don't use obsolete.dat when using mmseqs2, thus failed to find the newer 6qzp.

This pull request is to use obsolete.dat when using mmseqs2 template search.
With this modification the above error disappears.
