### PR TITLE
Fix paths in test_predict_structure.py

### DIFF
--- a/test/test_predict_structure.py
+++ b/test/test_predict_structure.py
@@ -25,6 +25,7 @@ import sys
 import os
 import subprocess
 import json
+from pathlib import Path
 
 import alphapulldown
 from alphapulldown import predict_structure
@@ -49,9 +50,9 @@ class TestScript(_TestBase):
 
         #Create a temporary directory for the output
         self.output_dir = tempfile.mkdtemp()
-        self.example_data_dir = os.path.join(os.path.dirname(os.getcwd()),"example_data")
-        self.protein_lists = os.path.join(self.example_data_dir, "custom_mode.txt")
-        self.monomer_objects_dir = os.path.join(os.path.dirname(os.getcwd()),"example_data")
+        self.test_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_data")
+        self.protein_lists = os.path.join(self.test_data_dir, "tiny_monomeric_features_homodimer.txt")
+        self.monomer_objects_dir = self.test_data_dir
 
         #Get path of the alphapulldown module
         alphapulldown_path = alphapulldown.__path__[0]
@@ -116,7 +117,11 @@ class TestScript(_TestBase):
 
     def testRunMonomer(self):
         """test run monomer structure prediction"""
-        self.oligomer_state_file = os.path.join(os.path.dirname(os.getcwd()),"example_data/homooligomer_state.txt")
+        self.example_data_dir = os.path.join(Path(os.path.abspath(__file__)).parent.parent.absolute(), "example_data")
+        print(self.example_data_dir)
+        self.protein_lists = os.path.join(self.example_data_dir, "custom_mode.txt")
+        self.monomer_objects_dir = self.example_data_dir
+        self.oligomer_state_file = os.path.join(self.example_data_dir, "homooligomer_state.txt")
         self.args = [
             sys.executable,
             self.script_path,


### PR DESCRIPTION
I fixed paths as the tests did not work for me anymore due to paths changed to example_data. I kept example_data for your monomeric test but you still need to push P03452.pkl to remote:

```
...F....
======================================================================
FAIL: testRunMonomer (__main__.TestScript)
test run monomer structure prediction
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_predict_structure.py", line 137, in testRunMonomer
    self._runCommonTests(result)
  File "test_predict_structure.py", line 82, in _runCommonTests
    self.assertEqual(result.returncode, 0, f"Script failed with output:\n{result.stdout}\n{result.stderr}")
AssertionError: 1 != 0 : Script failed with output:

I0519 19:36:21.961612 140737354024768 utils.py:214] checking if output_dir exists /scratch/jobs/28307183/tmpap_vfcbo
Traceback (most recent call last):
  File "/g/kosinski/kosinski/devel/AlphaPulldown/alphapulldown/run_multimer_jobs.py", line 380, in <module>
    app.run(main)
  File "/g/kosinski/kosinski/software/envs/AlphaPulldown2/lib/python3.8/site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/g/kosinski/kosinski/software/envs/AlphaPulldown2/lib/python3.8/site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/g/kosinski/kosinski/devel/AlphaPulldown/alphapulldown/run_multimer_jobs.py", line 360, in main
    multimers = create_homooligomers(
  File "/g/kosinski/kosinski/devel/AlphaPulldown/alphapulldown/run_multimer_jobs.py", line 230, in create_homooligomers
    monomer = load_monomer_objects(monomer_dir_dict, protein_name)
  File "/g/kosinski/kosinski/devel/AlphaPulldown/alphapulldown/utils.py", line 92, in load_monomer_objects
    target_path = monomer_dir_dict[f"{protein_name}.pkl"]
KeyError: 'P03452.pkl'


----------------------------------------------------------------------
Ran 8 tests in 2975.137s

FAILED (failures=1)
```