### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Activate the AlphaPulldown environment and install AlphaPulldown
 source activate AlphaPulldown
 
 python3 -m pip install alphapulldown==1.0.2
-pip install jax==0.4.20 jaxlib==0.4.16+cuda11.cudnn86 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install jax==0.4.23 jaxlib==0.4.23+cuda11.cudnn86 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
 **For older versions of AlphaFold**: 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Check if you have downloaded necessary parameters and databases (e.g. BFD, MGnif
 
 **Firstly**, install [Anaconda](https://www.anaconda.com/) and create AlphaPulldown environment, gathering necessary dependencies 
 ```bash
-conda create -n AlphaPulldown -c omnia -c bioconda -c conda-forge python==3.10 openmm==8.0 pdbfixer==1.9 kalign2 cctbx-base pytest importlib_metadata
+conda create -n AlphaPulldown -c omnia -c bioconda -c conda-forge python==3.10 openmm==8.0 pdbfixer==1.9 kalign2 cctbx-base pytest importlib_metadata hhsuite
 ```
 
-**Optionally**, if you do not have these software yet on your system, install [HMMER](http://hmmer.org/documentation.html), [HH-suite](https://github.com/soedinglab/hh-suite) from Anaconda
+**Optionally**, if you do not have it yet on your system, install [HMMER](http://hmmer.org/documentation.html) from Anaconda
 ```bash
 source activate AlphaPulldown
-conda install -c bioconda hmmer hhsuite
+conda install -c bioconda hmmer
 ```
 This usually works, but on some compute systems users may wish to use other versions or optimized builds of already installed HMMER and HH-suite.
 
@@ -67,7 +67,7 @@ Activate the AlphaPulldown environment and install AlphaPulldown
 source activate AlphaPulldown
 
 python3 -m pip install alphapulldown==1.0.2
-pip install jax==0.4.16 jaxlib==0.4.16+cuda11.cudnn86 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install jax==0.4.20 jaxlib==0.4.16+cuda11.cudnn86 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
 **For older versions of AlphaFold**: 

--- a/README.md
+++ b/README.md
@@ -46,20 +46,11 @@ Check if you have downloaded necessary parameters and databases (e.g. BFD, MGnif
     uniref90/                              # ~ 58 GB (download: 29.7 GB)
         uniref90.fasta
  ```
-
-## Installation using pip
+## Create Anaconda environment
 
 **Firstly**, install [Anaconda](https://www.anaconda.com/) and create AlphaPulldown environment, gathering necessary dependencies 
 ```bash
 conda create -n AlphaPulldown -c omnia -c bioconda -c conda-forge python==3.10 openmm==8.0 pdbfixer==1.9 kalign2 cctbx-base pytest importlib_metadata
-```
-
-**Secondly**, activate the AlphaPulldown environment and install AlphaPulldown
-```bash
-source activate AlphaPulldown
-
-python3 -m pip install alphapulldown==1.0.2
-pip install jax==0.4.16 jaxlib==0.4.16+cuda11.cudnn86 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
 **Optionally**, if you do not have these software yet on your system, install [HMMER](http://hmmer.org/documentation.html), [HH-suite](https://github.com/soedinglab/hh-suite) from Anaconda
@@ -68,6 +59,16 @@ source activate AlphaPulldown
 conda install -c bioconda hmmer hhsuite
 ```
 This usually works, but on some compute systems users may wish to use other versions or optimized builds of already installed HMMER and HH-suite.
+
+## Installation using pip
+
+Activate the AlphaPulldown environment and install AlphaPulldown
+```bash
+source activate AlphaPulldown
+
+python3 -m pip install alphapulldown==1.0.2
+pip install jax==0.4.16 jaxlib==0.4.16+cuda11.cudnn86 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+```
 
 **For older versions of AlphaFold**: 
 If you haven't updated your databases according to the requirements of AlphaFold 2.3.0, you can still use AlphaPulldown with your older version of AlphaFold database. Please follow the installation instructions on the [dedicated branch](https://github.com/KosinskiLab/AlphaPulldown/tree/AlphaFold-2.2.0)


### PR DESCRIPTION
A cosmetic rearrangement in order to:
1) separate conda from pip
2) have conda step in a separate heading so we can link to it from the developer guide