### PR TITLE
Improve resume predictions

### DIFF
--- a/alphapulldown/folding_backend/alphafold_backend.py
+++ b/alphapulldown/folding_backend/alphafold_backend.py
@@ -117,37 +117,6 @@ def _reset_template_features(feature_dict: Dict) -> None:
             feature_dict[key] = np.ones_like(value)
 
 
-def _read_from_prediction_result(output_dir: str, model_name: str, prediction_results: Dict) -> None:
-    """
-    Read prediction result from pkl and updates with the sequence and protein, if not present.
-    Parameters:
-    output_dir (str): The output directory with predictions;.
-    model_name (str): The name of the AF model that generated predictions.
-    prediction_results (Dict[str, Dict]): Individual predictions for each model.
-    """
-    result_output_path = os.path.join(output_dir, f"result_{model_name}.pkl")
-    with open(result_output_path, "rb") as f:
-        prediction_result = pickle.load(f)
-        # Update prediction_result with input seqs and unrelaxed protein
-        if "seqs" not in prediction_result.keys():
-            prediction_result.update(
-                {"seqs": multimeric_object.input_seqs if hasattr(multimeric_object,"input_seqs") else [multimeric_object.sequence]})
-        if "unrelaxed_protein" not in prediction_result.keys():
-            plddt_b_factors = np.repeat(
-                prediction_result['plddt'][:,
-                                            None], residue_constants.atom_type_num, axis=-1
-            )
-            unrelaxed_protein = protein.from_prediction(
-                features=processed_feature_dict,
-                result=prediction_result,
-                b_factors=plddt_b_factors,
-                remove_leading_feature_dimension=not model_runner.multimer_mode,
-            )
-            prediction_result.update(
-                {"unrelaxed_protein": unrelaxed_protein})
-    prediction_results.update({model_name: prediction_result})
-
-
 class AlphaFoldBackend(FoldingBackend):
     """
     A backend to perform structure prediction using AlphaFold.
@@ -319,19 +288,41 @@ class AlphaFoldBackend(FoldingBackend):
         prediction_results = {}
         START = 0
         multimeric_mode = multimeric_object.multimeric_mode if hasattr(multimeric_object, "multimeric_mode") else None
-        t_0 = time.time()
         original_feature_dict = copy(multimeric_object.feature_dict)
-        total_num_res = sum([len(s) for s in multimeric_object.input_seqs]) if hasattr(multimeric_object, "input_seqs") else len(multimeric_object.sequence)
         if allow_resume:
             logging.info(
             f"Now running predictions on {multimeric_object.description}. Checking existing results...")
             for model_index, (model_name, model_runner) in enumerate(model_runners.items()):
-                unrelaxed_pdb_path = os.path.join(
-                    output_dir, f"unrelaxed_{model_name}.pdb")
-                result_output_path = os.path.join(
-                    output_dir, f"result_{model_name}.pkl")
-                if os.path.exists(unrelaxed_pdb_path) and os.path.exists(result_output_path): #If --remove_result_pickle=True the predictions are done anew.
-                    _read_from_prediction_result(output_dir, model_name, prediction_results)
+                unrelaxed_pdb_path = os.path.join(output_dir, f"unrelaxed_{model_name}.pdb")
+                result_output_path = os.path.join(output_dir, f"result_{model_name}.pkl")
+                # If --remove_result_pickle=True the predictions are done anew.
+                if os.path.exists(unrelaxed_pdb_path) and os.path.exists(result_output_path):
+                    result_output_path = os.path.join(output_dir, f"result_{model_name}.pkl")
+                    with open(result_output_path, "rb") as f:
+                        prediction_result = pickle.load(f)
+                        # Update prediction_result with input seqs and unrelaxed protein
+                        if "seqs" not in prediction_result.keys():
+                            prediction_result.update(
+                                {"seqs": multimeric_object.input_seqs if hasattr(multimeric_object, "input_seqs") else [
+                                    multimeric_object.sequence]})
+                        if "unrelaxed_protein" not in prediction_result.keys():
+                            plddt_b_factors = np.repeat(
+                                prediction_result['plddt'][:,
+                                None], residue_constants.atom_type_num, axis=-1
+                            )
+                            model_random_seed = model_index + random_seed * len(model_runners)
+                            processed_feature_dict = model_runner.process_features(
+                                original_feature_dict, random_seed=model_random_seed
+                            )
+                            unrelaxed_protein = protein.from_prediction(
+                                features=processed_feature_dict,
+                                result=prediction_result,
+                                b_factors=plddt_b_factors,
+                                remove_leading_feature_dimension=not model_runner.multimer_mode,
+                            )
+                            prediction_result.update(
+                                {"unrelaxed_protein": unrelaxed_protein})
+                    prediction_results.update({model_name: prediction_result})
                     START = model_index + 1
                 else:
                     break
@@ -342,7 +333,8 @@ class AlphaFoldBackend(FoldingBackend):
         # first check whether the desired num_res and num_msa are specified for padding
         desired_num_res, desired_num_msa = kwargs.get(
             "desired_num_res", None), kwargs.get("desired_num_msa", None)
-        if (desired_num_res is not None) and (desired_num_msa is not None) and type(multimeric_object) == MultimericObject:
+        if ((desired_num_res is not None) and (desired_num_msa is not None) and
+                type(multimeric_object) == MultimericObject):
             # This means padding is required to speed up the process
             pad_input_features(feature_dict=original_feature_dict,
                                desired_num_msa=desired_num_msa, desired_num_res=desired_num_res)
@@ -350,6 +342,7 @@ class AlphaFoldBackend(FoldingBackend):
         num_models = len(model_runners)
         # Predict
         for model_index, (model_name, model_runner) in enumerate(model_runners.items()):
+            t_0 = time.time()
             model_random_seed = model_index + random_seed * num_models
             processed_feature_dict = model_runner.process_features(
                 original_feature_dict, random_seed=model_random_seed

--- a/alphapulldown/folding_backend/alphafold_backend.py
+++ b/alphapulldown/folding_backend/alphafold_backend.py
@@ -567,7 +567,7 @@ class AlphaFoldBackend(FoldingBackend):
         for idx, model_name in enumerate(ranked_order):
             prediction_result = prediction_results[model_name]
             figure_name = os.path.join(
-                output_dir, f"{multimeric_object.description}_pae_plot_ranked_{idx}_{model_name}.png")
+                output_dir, f"{multimeric_object.description}_PAE_plot_ranked_{idx}.png")
             plot_pae_from_matrix(
                 seqs=prediction_result['seqs'],
                 pae_matrix=prediction_result['predicted_aligned_error'],

--- a/alphapulldown/scripts/run_multimer_jobs.py
+++ b/alphapulldown/scripts/run_multimer_jobs.py
@@ -107,7 +107,7 @@ def main(argv):
         elif v is True:
             command_args[k] = ""
         elif isinstance(v, list):
-            command_args[k] = " ".join([str(x) for x in v])
+            command_args[k] = ",".join([str(x) for x in v])
         else:
             command_args[k] = v
 

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -19,7 +19,7 @@ from alphapulldown.utils.modelling_setup import create_interactors, create_custo
 logging.set_verbosity(logging.INFO)
 
 # Required arguments
-flags.DEFINE_multi_string(
+flags.DEFINE_list(
     'input', None,
     'Folds in format [fasta_path:number:start-stop],[...],.',
     short_name='i')
@@ -30,7 +30,7 @@ flags.DEFINE_string(
 flags.DEFINE_string(
     'data_directory', None,
     'Path to directory containing model weights and parameters.')
-flags.DEFINE_multi_string(
+flags.DEFINE_list(
     'features_directory', None,
     'Path to computed monomer features.')
 
@@ -92,7 +92,7 @@ flags.DEFINE_string('crosslinks', None, 'Path to crosslink information pickle fo
 # Post-processing settings
 flags.DEFINE_boolean('compress_result_pickles', False,
                      'Whether the result pickles are going to be gzipped. Default False.')
-flags.DEFINE_boolean('remove_result_pickles', True,
+flags.DEFINE_boolean('remove_result_pickles', False,
                      'Whether the result pickles are going to be removed')
 flags.DEFINE_boolean('use_ap_style', False,
                      'Change output directory to include a description of the fold '

--- a/test/check_predict_structure.py
+++ b/test/check_predict_structure.py
@@ -75,10 +75,11 @@ class TestScript(_TestBase):
         #Check if the directory contains five files starting from ranked and ending with .pdb
         self.assertEqual(len([f for f in os.listdir(os.path.join(self.output_dir, dirname)) if f.startswith("ranked") and f.endswith(".pdb")]), 5)
         #Check if the directory contains five files starting from result and ending with .pkl
-        self.assertEqual(len([f for f in os.listdir(os.path.join(self.output_dir, dirname)) if f.startswith("result") and f.endswith(".pkl")]), 1)
+        self.assertEqual(len([f for f in os.listdir(os.path.join(self.output_dir, dirname)) if f.startswith("result") and f.endswith(".pkl")]), 5)
         #Check if the directory contains five files starting from pae and ending with .json
         self.assertEqual(len([f for f in os.listdir(os.path.join(self.output_dir, dirname)) if f.startswith("pae") and f.endswith(".json")]), 5)
         #Check if the directory contains five files ending with png
+        print(os.listdir(os.path.join(self.output_dir, dirname)))
         self.assertEqual(len([f for f in os.listdir(os.path.join(self.output_dir, dirname)) if f.endswith(".png")]), 5)
         #Check if the directory contains ranking_debug.json
         self.assertTrue("ranking_debug.json" in os.listdir(os.path.join(self.output_dir, dirname)))
@@ -143,27 +144,28 @@ class TestScript(_TestBase):
         self.assertEqual(len([f for f in os.listdir(os.path.join(self.output_dir, dirname)) if f.startswith("relaxed") and f.endswith(".pdb")]), 0)
         self.assertIn("model_1_multimer_v3_pred_0", result.stdout + result.stderr)
 
-    @pytest.mark.xfail
+    #pytest.mark.xfail
     def testRun_3(self):
         """test run with relaxation for all models"""
-        self.args.append("--models_to_relax=all")
+        self.args.append("--models_to_relax=All")
         result = subprocess.run(self.args, capture_output=True, text=True)
         self._runCommonTests(result)
         self._runAfterRelaxTests(result)
         self.assertIn("model_1_multimer_v3_pred_0", result.stdout + result.stderr)
 
-    @pytest.mark.xfail
+    #@pytest.mark.xfail
     def testRun_4(self):
         """
         Test if the script can resume after all 5 models are finished, running amber relax on the 5 models
         """
         #Copy the example directory called "test" to the output directory
         shutil.copytree(os.path.join(self.test_data_dir,"P0DPR3_and_P0DPR3"), os.path.join(self.output_dir, "P0DPR3_and_P0DPR3"))
-        self.args.append("--models_to_relax=all")
+        self.args.append("--models_to_relax=All")
         result = subprocess.run(self.args, capture_output=True, text=True)
         self._runCommonTests(result)
         self._runAfterRelaxTests(result)
-        self.assertIn("ranking_debug.json exists. Skipping prediction. Restoring unrelaxed predictions and ranked order", result.stdout + result.stderr)
+        self.assertIn("All predictions for", result.stdout + result.stderr)
+        self.assertIn("are already completed.", result.stdout + result.stderr)
         
     def testRun_5(self):
         """


### PR DESCRIPTION
Read from pkl and update prediction results in the loop where the calculation of START is made. Don't update prediction_result with sequence and protein if already present in the dict. Read & update from pkl is moved to a separate function for clarity.