### PR TITLE
Convert predicted models to modelcif

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Check if you have downloaded necessary parameters and databases (e.g. BFD, MGnif
 
 **Firstly**, install [Anaconda](https://www.anaconda.com/) and create AlphaPulldown environment, gathering necessary dependencies 
 ```bash
-conda create -n AlphaPulldown -c omnia -c bioconda -c conda-forge python==3.10 openmm==8.0 pdbfixer==1.9 kalign2 cctbx-base pytest importlib_metadata hhsuite
+conda create -n AlphaPulldown -c omnia -c bioconda -c conda-forge python==3.10 openmm==8.0 pdbfixer==1.9 kalign2 cctbx-base pytest importlib_metadata hhsuite modelcif
 ```
 
 **Optionally**, if you do not have it yet on your system, install [HMMER](http://hmmer.org/documentation.html) from Anaconda

--- a/alphapulldown/folding_backend/alphafold_backend.py
+++ b/alphapulldown/folding_backend/alphafold_backend.py
@@ -486,6 +486,7 @@ class AlphaFoldBackend(FoldingBackend):
         models_to_relax: ModelsToRelax,
         zip_pickles: bool = False,
         remove_pickles: bool = False,
+        convert_to_modelcif: bool = True,
         use_gpu_relax: bool = True,
         pae_plot_style: str = "red_blue",
 
@@ -514,6 +515,8 @@ class AlphaFoldBackend(FoldingBackend):
         remove_pickles : bool, optional
             If True, removes the pickle files after post-processing is complete.
             Default is False.
+        convert_to_modelcif : bool, optional
+            If set to True, converts all predicted models to ModelCIF format, default is True.
         use_gpu_relax : bool, optional
             If set to True, utilizes GPU acceleration for the relaxation step, default is True.
         pae_plot_style : str, optional
@@ -653,21 +656,24 @@ class AlphaFoldBackend(FoldingBackend):
         #             template_file_path, ranked_output_path, temp_dir
         #         )
 
-        #Call convert_to_modelcif script
-        # parent_dir = os.path.dirname(os.path.dirname((os.path.abspath(__file__))))
-        # command = f"python3 {parent_dir}/scripts/convert_to_modelcif.py " \
-        #           f"--ap_output {output_dir} " \
-        #           f"--monomer_objects_dir {''.join(features_directory)}"
+        # Call convert_to_modelcif script
+        if convert_to_modelcif:
+            parent_dir = os.path.dirname(os.path.dirname((os.path.abspath(__file__))))
+            logging.info(f"Converting {output_dir} to ModelCIF format. "
+                         f" Feature dir(s): {features_directory}.")
+            command = f"python3 {parent_dir}/scripts/convert_to_modelcif.py " \
+                      f"--ap_output {output_dir} " \
+                      f"--monomer_objects_dir {','.join(features_directory)}"
 
-        #result = subprocess.run(command,
-        #                        check=True,
-        #                        shell=True,
-        #                        capture_output=True,
-        #                        text=True)
+            result = subprocess.run(command,
+                                   check=True,
+                                   shell=True,
+                                   capture_output=True,
+                                   text=True)
 
-        #logging.info(result.stdout)
-        #if result.stderr:
-        #    logging.error("Error:", result.stderr)
+            logging.info(result.stdout)
+            if result.stderr:
+               logging.error("Error:", result.stderr)
         post_prediction_process(
            output_dir,
            zip_pickles=zip_pickles,

--- a/alphapulldown/folding_backend/alphafold_backend.py
+++ b/alphapulldown/folding_backend/alphafold_backend.py
@@ -659,11 +659,9 @@ class AlphaFoldBackend(FoldingBackend):
         # Call convert_to_modelcif script
         if convert_to_modelcif:
             parent_dir = os.path.dirname(os.path.dirname((os.path.abspath(__file__))))
-            logging.info(f"Converting {output_dir} to ModelCIF format. "
-                         f" Feature dir(s): {features_directory}.")
+            logging.info(f"Converting {output_dir} to ModelCIF format...")
             command = f"python3 {parent_dir}/scripts/convert_to_modelcif.py " \
-                      f"--ap_output {output_dir} " \
-                      f"--monomer_objects_dir {','.join(features_directory)}"
+                      f"--ap_output {output_dir} "
 
             result = subprocess.run(command,
                                    check=True,
@@ -671,9 +669,10 @@ class AlphaFoldBackend(FoldingBackend):
                                    capture_output=True,
                                    text=True)
 
-            logging.info(result.stdout)
             if result.stderr:
-               logging.error("Error:", result.stderr)
+                logging.error("Error:", result.stderr)
+            else:
+                logging.info("All PDBs converted to ModelCIF format.")
         post_prediction_process(
            output_dir,
            zip_pickles=zip_pickles,

--- a/alphapulldown/scripts/convert_to_modelcif.py
+++ b/alphapulldown/scripts/convert_to_modelcif.py
@@ -688,6 +688,10 @@ def _get_software_with_parameters(sw_dict, other_dict):
             "sw": ["AlphaPulldown"],
             "method_type": ["coevolution MSA"],
         },
+        "use_hhsearch": {
+            "sw": ["AlphaPulldown"],
+            "method_type": ["coevolution MSA"],
+        },
         "skip_existing": {
             "sw": ["AlphaPulldown"],
             "method_type": ["coevolution MSA", "modeling"],
@@ -760,6 +764,7 @@ def _get_software_with_parameters(sw_dict, other_dict):
         "v",
         "verbosity",
         "xml_output_file",
+        "multiple_mmts"
     ]
     re_args = re.compile(
         r"(?:fasta_paths|multimeric_chains|multimeric_templates|protein)_\d+"

--- a/alphapulldown/scripts/convert_to_modelcif.py
+++ b/alphapulldown/scripts/convert_to_modelcif.py
@@ -160,13 +160,14 @@ class _Biopython2ModelCIF(modelcif.model.AbInitioModel):
         if "iptm" in scores_json:
             conf = scores_json["iptm+ptm"]
             iptm = scores_json["iptm"]
+            ptm = (conf - 0.8*iptm)/0.2
         elif "ptm" in scores_json:
-            conf = scores_json["ptm"]
             iptm = 0
+            ptm = scores_json["ptm"]
         self.qa_metrics.extend(
             (
                 _GlobalPLDDT(np.mean(scores_json["plddt"])),
-                _GlobalPTM(conf),
+                _GlobalPTM(ptm),
                 _GlobalIPTM(iptm),
             )
         )

--- a/alphapulldown/scripts/convert_to_modelcif.py
+++ b/alphapulldown/scripts/convert_to_modelcif.py
@@ -1239,8 +1239,12 @@ def _get_model_list(
     """Get the list of models to be converted.
 
     If `model_selected` is none, all models will be marked for conversion."""
-    cmplx = [d for d in os.listdir(ap_dir) if os.path.isdir(os.path.join(ap_dir, d))]
-    mdl_all_paths = [os.path.join(ap_dir, c) for c in cmplx]
+    if 'ranking_debug.json' in os.listdir(ap_dir): #One complex was given, not the root directory
+        cmplx = [os.path.basename(os.path.normpath(ap_dir))]
+        mdl_all_paths = [ap_dir]
+    else:
+        cmplx = [d for d in os.listdir(ap_dir) if os.path.isdir(os.path.join(ap_dir, d))]
+        mdl_all_paths = [os.path.join(ap_dir, c) for c in cmplx]
     result = []
 
     for c, specific_mdl_path in zip(cmplx, mdl_all_paths):

--- a/alphapulldown/scripts/create_individual_features.py
+++ b/alphapulldown/scripts/create_individual_features.py
@@ -106,6 +106,7 @@ def create_arguments(local_path_to_custom_template_db=None):
 
     use_small_bfd = FLAGS.db_preset == "reduced_dbs"
     flags_dict.update({"use_small_bfd": use_small_bfd})
+    flags_dict.update({"fasta_paths": FLAGS.fasta_paths})
 
     # Update pdb related flags
     if local_path_to_custom_template_db:

--- a/alphapulldown/scripts/create_individual_features.py
+++ b/alphapulldown/scripts/create_individual_features.py
@@ -337,7 +337,7 @@ def process_multimeric_features(feat, idx):
             temp_dir, protein, template_paths, chains)
         create_arguments(local_path_to_custom_db)
 
-        flags_dict.update({f"protein_{idx}": protein, f"multimeric_templates_{idx}": template_paths,
+        flags_dict.update({f"protein": protein, f"multimeric_templates_{idx}": template_paths,
                            f"multimeric_chains_{idx}": chains})
 
         if not FLAGS.use_mmseqs2:

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -9,8 +9,10 @@
 from absl import flags, app
 from os import makedirs
 from typing import Dict, List, Union, Tuple
-from os.path import join
+from os.path import join, basename
 from absl import logging
+import glob
+import shutil
 from alphapulldown.folding_backend import backend
 from alphapulldown.folding_backend.alphafold_backend import ModelsToRelax
 from alphapulldown.objects import MultimericObject, MonomericObject, ChoppedObject
@@ -217,6 +219,19 @@ def pre_modelling_setup(
     if flags.use_ap_style:
         output_dir = join(output_dir, object_to_model.description)
     makedirs(output_dir, exist_ok=True)
+    # Copy features metadata to output directory
+    for interactor in interactors:
+        for feature_dir in flags.features_directory:
+            meta_json = glob.glob(
+                join(feature_dir, f"{interactor.description}_feature_metadata_*.json")
+            )
+            if meta_json:
+                feature_json = meta_json[0]
+                logging.info(f"Copying {feature_json} to {output_dir}")
+                shutil.copyfile(feature_json, join(output_dir, basename(feature_json)))
+            else:
+                logging.warning(f"No feature metadata found for {interactor.description} in {output_dir}")
+
     return object_to_model, flags_dict, postprocess_flags, output_dir
 
 def main(argv):

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -86,6 +86,8 @@ flags.DEFINE_integer('random_seed', None, 'The random seed for the data '
                      'that even if this is set, Alphafold may still not be '
                      'deterministic, because processes like GPU inference are '
                      'nondeterministic.')
+flags.DEFINE_boolean('convert_to_modelcif', True,
+                     'Whether to convert predicted pdb files to modelcif format. Default True.')
 # AlphaLink2 settings
 flags.DEFINE_string('crosslinks', None, 'Path to crosslink information pickle for AlphaLink.')
 
@@ -209,6 +211,7 @@ def pre_modelling_setup(
         "use_gpu_relax": flags.use_gpu_relax,
         "models_to_relax": flags.models_to_relax,
         "features_directory": flags.features_directory,
+        "convert_to_modelcif": flags.convert_to_modelcif
     }
 
     if flags.use_ap_style:

--- a/alphapulldown/utils/file_handling.py
+++ b/alphapulldown/utils/file_handling.py
@@ -69,11 +69,8 @@ def parse_csv_file(csv_path, fasta_paths, mmt_dir, cluster=False):
                     protein_data[protein]["templates"].append(os.path.join(mmt_dir, template))
                     protein_data[protein]["chains"].append(chain)
             if not cluster:
-                # Ensure unique protein names by appending a counter
-                original_protein = protein
-                counter = protein_counters.get(protein, 0)
-                protein_counters[protein] = counter + 1
-                unique_protein = f"{protein}_{counter}" if counter > 0 else protein
+                # Ensure unique protein names by appending a chain id.
+                unique_protein = f"{protein}.{template}.{chain}"
                 protein_data[unique_protein] = {
                     "protein": unique_protein,
                     "sequence": protein_names[protein],


### PR DESCRIPTION
feature metadata for all features from the complex is now copied to the prediction dir.
convert_to_modelcif.py only takes the output dir; no need to provide feature_dirs anymore. 
convert_to_modelcif reads from jsons instead of pickles.
Multiple other adaptations to AP v.2 workflow in convert_to_modelcif.py.