### PR TITLE
Rearange backend initialisation

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -46,12 +46,12 @@ jobs:
           pip install -e alphafold --no-deps
           export PYTHONPATH=$PWD/AlphaLink2:$PYTHONPATH
           # install dependencies for AlphaLink backend
-          pip install torch==1.13.0+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
-          pip install setuptools==69.5.1 # Downgrade setuptools to avoid crashes when installing unicore
-          git clone https://github.com/dptech-corp/Uni-Core.git
-          cd Uni-Core
-          python setup.py install --disable-cuda-ext
-          cd ../
+          # pip install torch==1.13.0+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
+          # pip install setuptools==69.5.1 # Downgrade setuptools to avoid crashes when installing unicore
+          # git clone https://github.com/dptech-corp/Uni-Core.git
+          # cd Uni-Core
+          # python setup.py install --disable-cuda-ext
+          # cd .
           python test/test_python_imports.py
       - if: matrix.install-type == 'developer'
         run: |

--- a/alphapulldown/folding_backend/__init__.py
+++ b/alphapulldown/folding_backend/__init__.py
@@ -3,14 +3,13 @@
     Copyright (c) 2023 European Molecular Biology Laboratory
 
     Author: Valentin Maurer <valentin.maurer@embl-hamburg.de>
+            Dingquan Yu <dingquan.yu@embl-hamburg.de>
 """
 
 from typing import Dict, List
-
+from absl import logging
 from .alphafold_backend import AlphaFoldBackend
-from .alphalink_backend import AlphaLinkBackend
-from .unifold_backend import UnifoldBackend
-
+logging.set_verbosity(logging.INFO)
 
 class FoldingBackendManager:
     """
@@ -31,14 +30,28 @@ class FoldingBackendManager:
 
     def __init__(self):
         self._BACKEND_REGISTRY = {
-            "alphafold": AlphaFoldBackend,
-            "unifold": UnifoldBackend,
-            "alphalink": AlphaLinkBackend
+            "alphafold": AlphaFoldBackend
         }
+        self.import_backends()
         self._backend_name = "alphafold"
         self._backend = self._BACKEND_REGISTRY[self._backend_name]()
         self._backend_args = {}
 
+    def import_backends(self) -> None:
+        """Import all available backends"""
+        try:
+            from .alphalink_backend import AlphaLinkBackend
+            self._BACKEND_REGISTRY.update({"alphalink": AlphaLinkBackend})
+        except Exception as e:
+            logging.warning("Failed to import AlphaLinkBackend. Perhaps you haven't installed all the required dependencies.")
+        
+        try:
+            from .unifold_backend import UnifoldBackend
+            self._BACKEND_REGISTRY.update({"unifold": UnifoldBackend})
+        
+        except Exception as e:
+            logging.warning("Failed to import UnifoldBackend. Perhaps you haven't installed all the required dependencies.")
+        
     def __repr__(self):
         return f"<BackendManager: using {self._backend_name}>"
 

--- a/test/test_python_imports.py
+++ b/test/test_python_imports.py
@@ -1,5 +1,4 @@
 from alphapulldown.utils import *
-from alphapulldown.folding_backend import *
 import io
 import warnings
 import subprocess
@@ -13,8 +12,8 @@ from os import makedirs
 from typing import Dict, List
 from os.path import exists, join
 
-from alphapulldown.folding_backend import backend
-from alphapulldown.objects import MultimericObject
+from alphapulldown.folding_backend import FoldingBackendManager
+from alphapulldown.objects import MultimericObject, MonomericObject
 from alphapulldown.utils.modelling_setup import create_interactors
 from absl import logging
 logging.set_verbosity(logging.INFO)


### PR DESCRIPTION
This PR will make the imports of UnifoldBackend and AlphaLinkBackend optional and will handles the exception of these imports if they failed. It will make the installations of the extra dependencies optional instead and fixed the CI/CD crashes due to disk space error.