### PR TITLE
Change re for finding PAE.png plots

### DIFF
--- a/alphapulldown/analysis_pipeline/utils.py
+++ b/alphapulldown/analysis_pipeline/utils.py
@@ -14,7 +14,7 @@ from af2plots.plotter import plotter
 
 def display_pae_plots(subdir,figsize=(50, 50)):
     """A function to display all the pae plots in the subdir"""
-    pattern = r"ranked_(\d+)_model"
+    pattern = r"_PAE_plot_ranked_(\d+)"
     images = sorted([i for i in os.listdir(subdir) if ".png" in i],
                     key= lambda x: int(re.search(pattern,x).group(1)))
     if len(images) > 0:


### PR DESCRIPTION
create_report dies when trying to convert jupyter notebook to html. 
https://github.com/KosinskiLab/AlphaPulldown/blob/main/alphapulldown/analysis_pipeline/create_notebook.py#L71
To fix that we can adjust this regular expression for finding PAE.png plots: https://github.com/KosinskiLab/AlphaPulldown/blob/main/alphapulldown/analysis_pipeline/utils.py#L17 
to the *.png file names produced by AP:
https://github.com/KosinskiLab/AlphaPulldown/blob/main/alphapulldown/folding_backend/alphafold_backend.py#L595