### PR TITLE
Compatibility problem with new jax version (0.6.0)

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -38,12 +38,12 @@ jobs:
       - if: matrix.install-type == 'user'
         run: |
           pip install alphapulldown
-          pip install -U "jax[cuda12]"
+          pip install -U "jax[cuda12]"==0.5.3
 
       - if: matrix.install-type == 'developer'
         run: |
           pip install .
-          pip install -U "jax[cuda12]"
+          pip install -U "jax[cuda12]"==0.5.3
           # export PYTHONPATH=$PWD/AlphaLink2:$PYTHONPATH
           # install dependencies for AlphaLink backend
           # pip install torch==1.13.0+cu117 --extra-index-url https://download.pytorch.org/whl/cu117

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ python3 -m pip install alphapulldown
 ```
 
 ```bash
-pip install -U "jax[cuda12]"
+pip install -U "jax[cuda12]"==0.5.3
 ```
    
 > [!NOTE] 


### PR DESCRIPTION
Haiku package is not compatible with new jax version.



run_multimer_jobs.py --mode=custom \--num_cycle=3 \--num_predictions_per_model=1 \--compress_result_pickles=True \--output_path=./result_all_vs_all \--data_dir=/data/alphadata_v2 \--protein_lists=all_vs_all.txt \--monomer_objects_dir=/data/mmseq_pickle_feature \--remove_keys_from_pickles=False
Traceback (most recent call last):
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/bin/run_multimer_jobs.py", line 14, in <module>
    from alphapulldown.scripts.run_structure_prediction import FLAGS
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/alphapulldown/scripts/run_structure_prediction.py", line 25, in <module>
    from alphapulldown.folding_backend import backend
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/alphapulldown/folding_backend/__init__.py", line 11, in <module>
    from .alphafold_backend import AlphaFoldBackend
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/alphapulldown/folding_backend/alphafold_backend.py", line 25, in <module>
    from alphafold.relax import relax
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/alphafold/relax/relax.py", line 18, in <module>
    from alphafold.relax import amber_minimize
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/alphafold/relax/amber_minimize.py", line 24, in <module>
    from alphafold.model import folding
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/alphafold/model/folding.py", line 20, in <module>
    from alphafold.model import all_atom
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/alphafold/model/all_atom.py", line 40, in <module>
    from alphafold.model import utils
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/alphafold/model/utils.py", line 23, in <module>
    import haiku as hk
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/haiku/__init__.py", line 20, in <module>
    from haiku import experimental
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/haiku/experimental/__init__.py", line 55, in <module>
    from haiku.experimental import jaxpr_info
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/haiku/experimental/jaxpr_info.py", line 18, in <module>
    from haiku._src.jaxpr_info import as_html
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/haiku/_src/jaxpr_info.py", line 101, in <module>
    ComputeFlopsFn = Callable[[jax.core.JaxprEqn, Expression], int]
                               ^^^^^^^^^^^^^^^^^
  File "/home/emmanuel/anaconda3/envs/AlphaPulldown/lib/python3.11/site-packages/jax/_src/deprecations.py", line 54, in getattr
    raise AttributeError(message)
AttributeError: jax.core.JaxprEqn was removed in JAX v0.6.0. Use jax.extend.core.JaxprEqn instead, and see https://docs.jax.dev/en/latest/jax.extend.html for details.