### PR TITLE
Paired/Unpaired MSA switch

### DIFF
--- a/alphapulldown/folding_backend/alphafold3_backend.py
+++ b/alphapulldown/folding_backend/alphafold3_backend.py
@@ -804,8 +804,8 @@ class AlphaFold3Backend(FoldingBackend):
                                 id=base_chain.id,
                                 sequence=base_chain.sequence,
                                 ptms=base_chain.ptms,
-                                unpaired_msa=a3m_sliced,
-                                paired_msa='',
+                                unpaired_msa='',
+                                paired_msa=a3m_sliced,
                                 templates=base_chain.templates,
                             )
                             custom_unpaired_chain_ids.add(base_chain.id)


### PR DESCRIPTION
The paired MSA is sliced and placed in the unpaired MSA, while the paired MSA field is set to an empty string (""). This causes an issue with AlphaFold 3, because in this configuration AF3 ignores inter-protein paired MSAs and therefore does not use co-evolutionary information between proteins.