### PR TITLE
Re-pin numpy<2 after jax install in alphafold2 dockerfile

### DIFF
--- a/docker/alphafold2.dockerfile
+++ b/docker/alphafold2.dockerfile
@@ -64,6 +64,14 @@ RUN pip3 install --upgrade pip --no-cache-dir \
     && pip3 install --upgrade --no-cache-dir \
       "jax[cuda12]"==0.5.3
 
+# `pip install --upgrade "jax[cuda12]"==0.5.3` above drags in numpy 2.x, which makes
+# AlphaFold multimer fail at runtime: alphafold/data/msa_pairing.py does
+# `np.sum(x for x in feats)` and numpy>=2 raises
+# `TypeError: Calling np.sum(generator) is deprecated`. The numpy<2 pins earlier in
+# this file (conda + pyproject) run BEFORE the jax upgrade so they do not stick; re-pin
+# numpy<2 as the LAST dependency step. jax 0.5.3 runs fine with numpy 1.26.x.
+RUN pip install --no-cache-dir "numpy<2"
+
 # Strip Python caches to reduce layer size
 RUN find /opt/conda -type d -name "__pycache__" -prune -exec rm -rf {} + \
  && find /opt/conda -type f -name "*.pyc" -delete \


### PR DESCRIPTION
## Problem

The current `alphafold2` container (`docker://kosinskilab/alphafold2:2.4.0`, freshly built) ships **numpy 2.4.4**, which breaks **every AlphaFold-Multimer prediction** at the feature-pairing step, before inference:

```
File ".../alphafold/data/msa_pairing.py", line 464, in _merge_features_from_multiple_chains
    merged_example[feature_name] = np.sum(x for x in feats).astype(np.int32)
TypeError: Calling np.sum(generator) is deprecated. Use np.sum(np.fromiter(generator)) ...
```

`np.sum(generator)` is a hard error in numpy ≥ 2.0. So any pulldown/multimer job dies ~40 s in (pure CPU feature-merge), regardless of GPU.

## Root cause

`docker/alphafold2.dockerfile` line ~63-65 runs `pip install --upgrade "jax[cuda12]"==0.5.3` as the **last** dependency step, and that `--upgrade` pulls in numpy 2.x. The `numpy<2` pins that exist (conda block + `pyproject.toml` + `environment.yml`) all run **before** the jax upgrade, so they don't stick.

Commit `fff63051` ("Tests (#600)") removed the trailing `RUN pip install --no-cache-dir "numpy<2"` (originally added in `69af382a`, "Force numpy<2 installation") that previously force-downgraded numpy as the final step. Without it, rebuilds of `:2.4.0` bake in numpy 2.x. (Docker tags are mutable, so older pulls still worked — which is why this surfaced only on a recent rebuild.)

## Fix

Restore a trailing `RUN pip install --no-cache-dir "numpy<2"` after the jax install, so numpy is re-pinned as the final dependency step.

**Verified:** a working AF2 image and the broken one both have **jax 0.5.3**; the only difference is numpy (1.26.4 works vs 2.4.4 broken). jax 0.5.3 runs fine with numpy 1.26.x, and full multimer inference (`model_1_multimer_v3`, relaxation, ranking) completes with numpy 1.26.4.

Note: a clean AF2 image also needs `setuptools<82` (already pinned at line 51) — without it, pdbfixer fails with `ModuleNotFoundError: pkg_resources`.