### PR TITLE
Refactor oligo handling to preserve output directory order name

### DIFF
--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -393,7 +393,7 @@ def pre_modelling_setup(
            output_dir = join(output_dir, object_to_model.description)
         else :
             old_output_dir = output_dir
-            for oligo in set(list_oligo) :
+            for oligo in list(dict.fromkeys(list_oligo)) :
                 number_oligo = list_oligo.count(oligo)
                 if output_dir == old_output_dir :
                     if number_oligo != 1 :


### PR DESCRIPTION
Problem :
Generate complex containing homo-oligomer create a randomly output name.
exemple :
Input : P15076:5;P33790
Possible output name directory : P15076_homo_5er_and_P33790 or P33790_and_P15076_homo_5er

Cause : 
Create a set() randomly reorganising protein order.

Patch : 
Replace set() by list(dict.fromkeys())
