### PR TITLE
feat: add resident inference batches

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -159,15 +159,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: webfactory/ssh-agent@v0.9.0
+        if: github.event_name != 'pull_request'
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - run: rm -rf /opt/hostedtoolcache
       - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/setup-buildx-action@v3
+      - name: Build alphafold2 container and smoke-test resident batch command
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/alphafold2.dockerfile
+          push: false
       - name: Build and push alphafold2 container
         if: github.event_name == 'push'
         uses: docker/build-push-action@v5

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,12 @@
+# Domain glossary
+
+- **Prediction job**: one independent fold request, including all chains that
+  compose that fold and its output directory.
+- **Prediction batch**: an ordered set of independent prediction jobs that share
+  one homogeneous backend and model configuration.
+- **Resident inference**: executing a prediction batch while keeping one set of
+  model runners initialized for the lifetime of the batch.
+- **Batch manifest**: a JSONL description of prediction jobs. It describes work;
+  it does not change fold composition semantics.
+- **Job failure**: a recoverable exception associated with one prediction job.
+  It is reported after remaining jobs have been attempted.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,3 +10,6 @@
   it does not change fold composition semantics.
 - **Job failure**: a recoverable exception associated with one prediction job.
   It is reported after remaining jobs have been attempted.
+- **Fold preparation**: building the object to model for one prediction job and its
+  output directory, including AlphaPulldown-style naming and feature-metadata copying.
+  Shared by the single-fold command and the resident batch so the two cannot diverge.

--- a/README.md
+++ b/README.md
@@ -580,7 +580,10 @@ length_filter_fetch_uniprot: true     # set false for fully offline runs
 Many short, inference-only predictions can spend more time waiting in the SLURM queue
 than running. To amortise that wait, several folds can share a single
 `structure_inference` job: the job runs `run_structure_prediction.py` once per fold in a
-loop, so the folds queue **once** between them instead of once each.
+loop, so the folds queue **once** between them instead of once each. With a current
+AlphaPulldown container, batches of two or more instead use
+`run_structure_prediction_batch.py`: one resident process loads the model once and keeps
+the folds independent.
 
 ```yaml
 batch_size: 4          # max folds per inference job (1 = one job per fold, the default)
@@ -593,19 +596,20 @@ batch_max_tokens: 0    # optional cap on summed residues per batch (0 = no cap)
 - Folds are grouped **by size**, so a batch's memory tracks its largest fold and its
   walltime scales with the number of folds. `batch_max_tokens` keeps a batch's total
   work within the partition's `MaxTime`; a single oversized fold always runs alone.
-- Works with both AlphaFold2 and AlphaFold3. Each fold is predicted by its own CLI call
-  (a single call with several folds would be **merged into one complex** by the AF3
-  backend), so the per-fold model load is paid each time; a shared
-  `--jax_compilation_cache_dir` is set automatically so later folds reuse earlier
-  compilations (especially AF3 buckets), recovering most of the compile cost.
+- Works with both AlphaFold2 and AlphaFold3. A JSONL manifest distinguishes independent
+  folds from the chains inside each fold, so AF3 does not merge separate folds. The
+  backend and model runners are initialized once per batch. Containers predating the
+  batch command automatically fall back to the per-fold loop.
 - For AlphaFold2 batches, `--allow_resume` is enabled automatically, so if a job is
   interrupted a rerun skips folds whose outputs already exist (AlphaFold3 does not accept
   that flag, so its batches recompute the unfinished folds on rerun).
 - Analysis and reports are unaffected — `alphajudge` still runs per fold (one
   `interfaces.csv` + `report.pdf` each) and the recursive summary still aggregates them.
 - **Trade-off:** a batch is one SLURM job, so a failure reruns the whole batch (minus the
-  folds resume can skip) and the allocation is sized for the batch's largest fold. Keep
-  `batch_size` modest and pair it with `batch_max_tokens` for heterogeneous fold sizes.
+  folds resume can skip), although the resident command attempts the remaining folds
+  before returning a failure summary. The allocation is sized for the batch's largest
+  fold. Keep `batch_size` modest and pair it with `batch_max_tokens` for heterogeneous
+  fold sizes.
 
 > [!NOTE]
 > **AlphaFold3 batching depends on your container + shared filesystem.** A batched AF3 job

--- a/README.md
+++ b/README.md
@@ -606,10 +606,12 @@ batch_max_tokens: 0    # optional cap on summed residues per batch (0 = no cap)
 - Analysis and reports are unaffected — `alphajudge` still runs per fold (one
   `interfaces.csv` + `report.pdf` each) and the recursive summary still aggregates them.
 - **Trade-off:** a batch is one SLURM job, so a failure reruns the whole batch (minus the
-  folds resume can skip), although the resident command attempts the remaining folds
-  before returning a failure summary. The allocation is sized for the batch's largest
-  fold. Keep `batch_size` modest and pair it with `batch_max_tokens` for heterogeneous
-  fold sizes.
+  folds resume can skip). The resident command catches ordinary Python exceptions and
+  attempts the remaining folds before returning a failure summary. A native CUDA/XLA
+  abort, process termination, or backend left unusable after an error cannot be isolated
+  and may stop or poison the rest of the batch. The allocation is sized for the batch's
+  largest fold. Keep `batch_size` modest and pair it with `batch_max_tokens` for
+  heterogeneous fold sizes.
 
 > [!NOTE]
 > **AlphaFold3 batching depends on your container + shared filesystem.** A batched AF3 job

--- a/alphapulldown/fold_preparation.py
+++ b/alphapulldown/fold_preparation.py
@@ -1,0 +1,140 @@
+"""Turn the interactors of one fold into the object to model, and its output directory.
+
+Both the single-fold command and the resident batch command need this, and they used to
+carry near-identical copies that had drifted apart: the copy in the single-fold path
+reassigned its metadata glob inside the feature-directory loop and tested it outside, so
+only the last feature directory could contribute. The same fold produced different output
+depending on which command ran it. One implementation, one meaning.
+"""
+
+from __future__ import annotations
+
+import glob
+import lzma
+import os
+import pickle
+import shutil
+from typing import Any, List, Tuple, Union
+
+from absl import logging
+
+from alphapulldown.objects import ChoppedObject, MonomericObject, MultimericObject
+
+
+# Most filesystems reject paths longer than this.
+_MAX_PATH_LENGTH = 4096
+
+
+def _interactor_description(interactor: Any) -> str | None:
+    """Name under which this interactor's feature metadata was written, if any."""
+    if isinstance(interactor, ChoppedObject):
+        return interactor.monomeric_description
+    if isinstance(interactor, MonomericObject):
+        return interactor.description
+    return None
+
+
+def _output_directory_for(description: str, output_dir: str) -> str:
+    """AlphaPulldown-style output directory, collapsing repeated chains to `_homo_Ner`."""
+    oligomers = description.split("_and_")
+    if len(oligomers) == len(set(oligomers)):
+        return os.path.join(output_dir, description)
+    fragments = []
+    for oligomer in dict.fromkeys(oligomers):
+        count = oligomers.count(oligomer)
+        fragments.append(oligomer if count == 1 else f"{oligomer}_homo_{count}er")
+    return os.path.join(output_dir, "_and_".join(fragments))
+
+
+def _copy_feature_metadata(interactors: List[Any], flags: Any, output_dir: str) -> None:
+    """Copy each interactor's most recent feature metadata, decompressing `.json.xz`.
+
+    Every configured feature directory is considered, not just the last one, and the
+    newest match across all of them wins.
+    """
+    for interactor in interactors:
+        description = _interactor_description(interactor)
+        if description is None:
+            continue
+        metadata_files: list[str] = []
+        for feature_dir in flags.features_directory:
+            metadata_files.extend(
+                glob.glob(
+                    os.path.join(
+                        feature_dir, f"{description}_feature_metadata_*.json*"
+                    )
+                )
+            )
+        if not metadata_files:
+            logging.warning(
+                "No feature metadata found for %s in %s",
+                description,
+                ", ".join(map(str, flags.features_directory)),
+            )
+            continue
+        latest = max(metadata_files, key=os.path.getmtime)
+        destination = os.path.join(output_dir, os.path.basename(latest))
+        if latest.endswith(".json.xz"):
+            destination = destination[: -len(".xz")]
+            logging.info("Decompressing %s to %s", latest, destination)
+            with lzma.open(latest, "rb") as source, open(destination, "wb") as target:
+                target.write(source.read())
+        else:
+            logging.info("Copying %s to %s", latest, output_dir)
+            shutil.copyfile(latest, destination)
+
+
+def prepare_fold(
+    interactors: List[Union[MonomericObject, ChoppedObject]],
+    output_dir: str,
+    flags: Any,
+) -> Tuple[Union[MultimericObject, MonomericObject, ChoppedObject], str]:
+    """Build the object to model for one fold and create its output directory.
+
+    ``flags`` is the parsed invocation (absl ``FLAGS`` or an equivalent), read for
+    ``pair_msa``, the multimeric-template settings, ``save_features_for_multimeric_object``,
+    ``use_ap_style`` and ``features_directory``.
+    """
+    if (
+        len(interactors) > 1
+        and flags.pair_msa
+        and any(getattr(interactor, "skip_msa", False) for interactor in interactors)
+    ):
+        raise ValueError(
+            "--skip_msa generates query-only MSAs and cannot be combined with "
+            "--pair_msa=True. Re-run structure prediction with --pair_msa=False."
+        )
+
+    if len(interactors) > 1:
+        object_to_model = MultimericObject(
+            interactors=interactors,
+            pair_msa=flags.pair_msa,
+            multimeric_template=flags.multimeric_template,
+            multimeric_template_meta_data=flags.description_file,
+            multimeric_template_dir=flags.path_to_mmt,
+            threshold_clashes=flags.threshold_clashes,
+            hb_allowance=flags.hb_allowance,
+            plddt_threshold=flags.plddt_threshold,
+        )
+        if flags.save_features_for_multimeric_object:
+            with open(
+                os.path.join(output_dir, "multimeric_object_features.pkl"), "wb"
+            ) as handle:
+                pickle.dump(MultimericObject.feature_dict, handle)
+    else:
+        object_to_model = interactors[0]
+        object_to_model.input_seqs = [object_to_model.sequence]
+
+    if flags.use_ap_style:
+        output_dir = _output_directory_for(object_to_model.description, output_dir)
+
+    if len(output_dir) > _MAX_PATH_LENGTH:
+        logging.warning(
+            "Output directory path is too long: %s. "
+            "Please use a shorter path with --output_directory.",
+            output_dir,
+        )
+    os.makedirs(output_dir, exist_ok=True)
+
+    _copy_feature_metadata(interactors, flags, output_dir)
+    return object_to_model, output_dir

--- a/alphapulldown/folding_backend/alphafold2_backend.py
+++ b/alphapulldown/folding_backend/alphafold2_backend.py
@@ -507,6 +507,18 @@ class AlphaFold2Backend(FoldingBackend):
         from alphafold.model import config
         from alphafold.model import data, model
 
+        # AlphaFold2 inference is JAX-compiled, and a fresh process recompiles every
+        # model runner. Honour a persistent on-disk compile cache when one is given.
+        jax_compilation_cache_dir = kwargs.get("jax_compilation_cache_dir")
+        if jax_compilation_cache_dir:
+            import jax
+
+            jax.config.update(
+                "jax_compilation_cache_dir", str(jax_compilation_cache_dir)
+            )
+            jax.config.update("jax_persistent_cache_min_compile_time_secs", 0)
+            jax.config.update("jax_persistent_cache_min_entry_size_bytes", 0)
+
         num_ensemble = 1
         model_runners = {}
         model_names = config.MODEL_PRESETS[model_name]
@@ -686,9 +698,15 @@ class AlphaFold2Backend(FoldingBackend):
         # first check whether the desired num_res and num_msa are specified for padding
         desired_num_res, desired_num_msa = kwargs.get(
             "desired_num_res", None), kwargs.get("desired_num_msa", None)
-        if ((desired_num_res is not None) and (desired_num_msa is not None) and
+        if (desired_num_res is not None and
                 type(multimeric_object) == MultimericObject):
-            # This means padding is required to speed up the process
+            # Padding every fold in a batch to one shape lets a resident session compile
+            # once instead of once per fold. num_res is the dimension that varies between
+            # folds; the MSA dimension is fixed by the model config during
+            # process_features, so default it to this fold's own depth (a no-op pad) when
+            # a batch-wide bound was not supplied.
+            if desired_num_msa is None:
+                desired_num_msa = int(original_feature_dict['msa'].shape[0])
             pad_input_features(feature_dict=original_feature_dict,
                                desired_num_msa=desired_num_msa, desired_num_res=desired_num_res)
             original_feature_dict['num_alignments'] = np.array([desired_num_msa])

--- a/alphapulldown/inference_flags.py
+++ b/alphapulldown/inference_flags.py
@@ -1,0 +1,141 @@
+"""One home for the inference flag set: which flags each backend accepts, and how the
+parsed invocation becomes the configuration passed to ``backend.setup``.
+
+Both facts used to be stated more than once. The per-backend flag sets were also copied
+by hand into AlphaPulldownSnakemake's ``common.smk``, where they drifted. The
+configuration dict was retyped verbatim in two places, and because every backend swallows
+what it does not recognise in ``**kwargs``, a mistyped key in either copy was dropped in
+silence rather than reported.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping
+
+
+# Accepted by every backend.
+COMMON_FLAGS = frozenset({
+    "input", "output_directory", "data_directory", "features_directory",
+    "protein_delimiter", "fold_backend", "random_seed", "storage_mode",
+})
+
+# AlphaFold2 and the AlphaFold2-derived backends.
+AF2_LIKE_FLAGS = frozenset({
+    "compress_result_pickles", "remove_result_pickles", "models_to_relax",
+    "relax_best_score_threshold", "remove_keys_from_pickles",
+    "convert_to_modelcif", "allow_resume",
+    "num_cycle", "num_predictions_per_model", "pair_msa",
+    "save_features_for_multimeric_object", "skip_templates",
+    "msa_depth_scan", "multimeric_template", "model_names", "msa_depth",
+    "description_file", "path_to_mmt", "threshold_clashes", "hb_allowance",
+    "plddt_threshold", "desired_num_res", "desired_num_msa",
+    "benchmark", "model_preset", "use_ap_style", "use_gpu_relax", "dropout",
+    # AF2 inference is JAX-compiled, so a persistent compile cache helps it too.
+    "jax_compilation_cache_dir",
+})
+
+ALPHALINK_EXTRA_FLAGS = frozenset({"crosslinks"})
+
+AF3_FLAGS = frozenset({
+    "jax_compilation_cache_dir", "buckets", "flash_attention_implementation",
+    "num_diffusion_samples", "num_seeds", "debug_templates", "debug_msas",
+    "num_recycles", "save_embeddings", "save_distogram", "use_ap_style",
+    "convert_to_modelcif",
+})
+
+FLAGS_BY_BACKEND: Mapping[str, frozenset] = {
+    "alphafold2": COMMON_FLAGS | AF2_LIKE_FLAGS,
+    "alphalink": COMMON_FLAGS | AF2_LIKE_FLAGS | ALPHALINK_EXTRA_FLAGS,
+    "alphafold3": COMMON_FLAGS | AF3_FLAGS,
+}
+
+
+def unsupported_flags(backend_name: str, present: Iterable[str]) -> list[str]:
+    """Flag names the named backend does not accept. Unknown backend: nothing to say."""
+    allowed = FLAGS_BY_BACKEND.get(backend_name)
+    if allowed is None:
+        return []
+    return sorted(set(present) - allowed)
+
+
+# Configuration key -> attribute on the parsed invocation. One list, so a key can be
+# mistyped in exactly one place and a wrong attribute name fails loudly at build time.
+_MODEL_FLAG_SOURCES: Mapping[str, str] = {
+    "num_cycle": "num_cycle",
+    "model_dir": "data_directory",
+    "num_predictions_per_model": "num_predictions_per_model",
+    "crosslinks": "crosslinks",
+    "desired_num_res": "desired_num_res",
+    "desired_num_msa": "desired_num_msa",
+    "skip_templates": "skip_templates",
+    "allow_resume": "allow_resume",
+    "num_diffusion_samples": "num_diffusion_samples",
+    "num_recycles": "num_recycles",
+    "return_embeddings": "save_embeddings",
+    "return_distogram": "save_distogram",
+    "flash_attention_implementation": "flash_attention_implementation",
+    "buckets": "buckets",
+    "jax_compilation_cache_dir": "jax_compilation_cache_dir",
+    "features_directory": "features_directory",
+    "num_seeds": "num_seeds",
+    "debug_templates": "debug_templates",
+    "debug_msas": "debug_msas",
+    "dropout": "dropout",
+}
+
+_POSTPROCESS_FLAG_SOURCES: Mapping[str, str] = {
+    "compress_pickles": "compress_result_pickles",
+    "remove_pickles": "remove_result_pickles",
+    "remove_keys_from_pickles": "remove_keys_from_pickles",
+    "storage_mode": "storage_mode",
+    "use_gpu_relax": "use_gpu_relax",
+    "models_to_relax": "models_to_relax",
+    "relax_best_score_threshold": "relax_best_score_threshold",
+    "features_directory": "features_directory",
+    "convert_to_modelcif": "convert_to_modelcif",
+}
+
+# Keys a backend's setup() may legitimately be given. Backends ignore what they do not
+# use, so this set is the only thing standing between a mistyped key and silence.
+MODEL_CONFIGURATION_KEYS = frozenset(_MODEL_FLAG_SOURCES) | {
+    "model_name",
+    # added for AlphaFold2 multimer batches
+    "msa_depth_scan",
+    "model_names_custom",
+    "msa_depth",
+}
+
+
+def model_flags(flags: Any) -> Dict[str, Any]:
+    """Configuration for ``backend.setup`` built from the parsed invocation."""
+    configuration = {
+        key: getattr(flags, attribute)
+        for key, attribute in _MODEL_FLAG_SOURCES.items()
+    }
+    configuration["model_name"] = (
+        "multimer_af2_crop" if flags.fold_backend == "alphalink" else "monomer_ptm"
+    )
+    return configuration
+
+
+def postprocess_flags(flags: Any) -> Dict[str, Any]:
+    """Configuration for ``backend.postprocess`` built from the parsed invocation."""
+    return {
+        key: getattr(flags, attribute)
+        for key, attribute in _POSTPROCESS_FLAG_SOURCES.items()
+    }
+
+
+def validate_model_configuration(configuration: Mapping[str, Any]) -> None:
+    """Reject configuration keys no backend consumes.
+
+    ``setup(**configuration)`` lets every backend absorb keys meant for another one in
+    ``**kwargs``, so without this a mistyped key is dropped without a word and the
+    setting it was meant to carry simply never takes effect.
+    """
+    unknown = sorted(set(configuration) - MODEL_CONFIGURATION_KEYS)
+    if unknown:
+        raise ValueError(
+            f"Unknown model configuration key(s): {unknown}. "
+            "Backends ignore keys they do not use, so this would otherwise be silent."
+        )

--- a/alphapulldown/prediction_batch.py
+++ b/alphapulldown/prediction_batch.py
@@ -264,6 +264,9 @@ class PreparedPredictionAdapter:
         return self._model_flags
 
     def setup(self, configuration: Dict[str, Any]) -> _AlphaPulldownSession:
+        from alphapulldown.inference_flags import validate_model_configuration
+
+        validate_model_configuration(configuration)
         self._backend.change_backend(backend_name=self._fold_backend)
         return _AlphaPulldownSession(
             dict(configuration), self._backend.setup(**configuration)
@@ -305,30 +308,67 @@ class AlphaPulldownPredictionAdapter:
         self._parsed_jobs: Dict[str, Tuple[list, Tuple[str, ...]]] = {}
 
     def _base_model_flags(self) -> Dict[str, Any]:
-        flags = self._flags
-        return {
-            "model_name": "monomer_ptm",
-            "num_cycle": flags.num_cycle,
-            "model_dir": flags.data_directory,
-            "num_predictions_per_model": flags.num_predictions_per_model,
-            "crosslinks": flags.crosslinks,
-            "desired_num_res": flags.desired_num_res,
-            "desired_num_msa": flags.desired_num_msa,
-            "skip_templates": flags.skip_templates,
-            "allow_resume": flags.allow_resume,
-            "num_diffusion_samples": flags.num_diffusion_samples,
-            "num_recycles": flags.num_recycles,
-            "return_embeddings": flags.save_embeddings,
-            "return_distogram": flags.save_distogram,
-            "flash_attention_implementation": flags.flash_attention_implementation,
-            "buckets": flags.buckets,
-            "jax_compilation_cache_dir": flags.jax_compilation_cache_dir,
-            "features_directory": flags.features_directory,
-            "num_seeds": flags.num_seeds,
-            "debug_templates": flags.debug_templates,
-            "debug_msas": flags.debug_msas,
-            "dropout": flags.dropout,
-        }
+        from alphapulldown.inference_flags import model_flags
+
+        return model_flags(self._flags)
+
+    def _postprocess_flags(self) -> Dict[str, Any]:
+        from alphapulldown.inference_flags import postprocess_flags
+
+        return postprocess_flags(self._flags)
+
+    def configuration_for(self, job: PredictionJob) -> Dict[str, Any]:
+        del job
+        return self._model_flags
+
+    def setup(self, configuration: Dict[str, Any]) -> _AlphaPulldownSession:
+        from alphapulldown.inference_flags import validate_model_configuration
+
+        validate_model_configuration(configuration)
+        self._backend.change_backend(backend_name=self._fold_backend)
+        return _AlphaPulldownSession(
+            dict(configuration), self._backend.setup(**configuration)
+        )
+
+    def _random_seed(self, session: _AlphaPulldownSession) -> int:
+        if self._requested_random_seed is not None:
+            return self._requested_random_seed
+        if self._fold_backend == "alphafold2":
+            count = len(session.backend_values["model_runners"])
+            return random.randrange(sys.maxsize // count)
+        if self._fold_backend == "alphafold3":
+            return random.randrange(2**32 - 1)
+        return random.randrange(sys.maxsize)
+
+    def predict(self, session: _AlphaPulldownSession, job: PredictionJob) -> None:
+        del job
+        predicted_jobs = self._backend.predict(
+            **session.backend_values,
+            objects_to_model=self._objects_to_model,
+            random_seed=self._random_seed(session),
+            **session.configuration,
+        )
+        for predicted_job in predicted_jobs:
+            self._backend.postprocess(
+                **self._postprocess_flags,
+                multimeric_object=predicted_job["object"],
+                prediction_results=predicted_job["prediction_results"],
+                output_dir=predicted_job["output_dir"],
+            )
+
+
+class AlphaPulldownPredictionAdapter:
+    """Adapter from prediction jobs to AlphaPulldown's folding backends."""
+
+    def __init__(self, prediction_flags: Any, *, backend: Any) -> None:
+        self._flags = prediction_flags
+        self._backend = backend
+        self._parsed_jobs: Dict[str, Tuple[list, Tuple[str, ...]]] = {}
+
+    def _base_model_flags(self) -> Dict[str, Any]:
+        from alphapulldown.inference_flags import model_flags
+
+        return model_flags(self._flags)
 
     def _postprocess_flags(self) -> Dict[str, Any]:
         flags = self._flags
@@ -382,6 +422,9 @@ class AlphaPulldownPredictionAdapter:
         return model_flags
 
     def setup(self, configuration: Dict[str, Any]) -> _AlphaPulldownSession:
+        from alphapulldown.inference_flags import validate_model_configuration
+
+        validate_model_configuration(configuration)
         self._backend.change_backend(backend_name=self._flags.fold_backend)
         backend_values = self._backend.setup(**configuration)
         return _AlphaPulldownSession(dict(configuration), backend_values)

--- a/alphapulldown/prediction_batch.py
+++ b/alphapulldown/prediction_batch.py
@@ -12,7 +12,7 @@ import pickle
 import random
 import shutil
 import sys
-from typing import Any, Dict, Protocol, Tuple, Union
+from typing import Any, Dict, Optional, Protocol, Tuple, Union
 
 
 PathLike = Union[str, Path]
@@ -50,6 +50,40 @@ class PredictionBatchSummary:
     @property
     def exit_code(self) -> int:
         return 1 if self.failures else 0
+
+
+@dataclass(frozen=True)
+class PredictionBatchOutcome:
+    """Command-level result, including errors that reject the whole batch."""
+
+    summary: Optional[PredictionBatchSummary] = None
+    rejection: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if (self.summary is None) == (self.rejection is None):
+            raise ValueError(
+                "PredictionBatchOutcome requires exactly one of summary or rejection"
+            )
+
+    @property
+    def exit_code(self) -> int:
+        if self.rejection is not None:
+            return 2
+        if self.summary is None:
+            raise RuntimeError("Prediction batch outcome has no result")
+        return self.summary.exit_code
+
+    @property
+    def summary_message(self) -> str:
+        if self.rejection is not None:
+            return "Prediction batch summary: 0 completed, batch rejected"
+        if self.summary is None:
+            raise RuntimeError("Prediction batch outcome has no result")
+        return (
+            "Prediction batch summary: "
+            f"{len(self.summary.completed_job_ids)} completed, "
+            f"{len(self.summary.failures)} failed"
+        )
 
 
 class PredictionAdapter(Protocol):
@@ -181,6 +215,26 @@ class PredictionBatch:
                     )
                 )
         return cls(tuple(jobs))
+
+
+def execute_prediction_manifest(
+    manifest_path: PathLike, adapter: PredictionAdapter
+) -> PredictionBatchOutcome:
+    """Execute a manifest, representing contract violations without a traceback."""
+    try:
+        batch = PredictionBatch.from_jsonl(manifest_path)
+    except PredictionBatchError as exc:
+        return PredictionBatchOutcome(rejection=str(exc))
+    except (OSError, UnicodeError) as exc:
+        manifest = Path(manifest_path).expanduser().resolve()
+        return PredictionBatchOutcome(
+            rejection=f"Cannot read prediction batch manifest {manifest}: {exc}"
+        )
+    try:
+        summary = batch.run(adapter)
+    except PredictionBatchError as exc:
+        return PredictionBatchOutcome(rejection=str(exc))
+    return PredictionBatchOutcome(summary=summary)
 
 
 @dataclass(frozen=True)

--- a/alphapulldown/prediction_batch.py
+++ b/alphapulldown/prediction_batch.py
@@ -1,0 +1,508 @@
+"""Resident execution of independent structure-prediction jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import glob
+import json
+import lzma
+import os
+from pathlib import Path
+import pickle
+import random
+import shutil
+import sys
+from typing import Any, Dict, Protocol, Tuple, Union
+
+
+PathLike = Union[str, Path]
+
+
+class PredictionBatchError(ValueError):
+    """A batch manifest does not satisfy the public contract."""
+
+
+@dataclass(frozen=True)
+class PredictionJob:
+    """One independent fold in a prediction batch."""
+
+    job_id: str
+    input: str
+    output_directory: Path
+
+
+@dataclass(frozen=True)
+class PredictionFailure:
+    """One recoverable job failure."""
+
+    job_id: str
+    message: str
+    exception: Exception
+
+
+@dataclass(frozen=True)
+class PredictionBatchSummary:
+    """Observable outcome of running a prediction batch."""
+
+    completed_job_ids: Tuple[str, ...]
+    failures: Tuple[PredictionFailure, ...]
+
+    @property
+    def exit_code(self) -> int:
+        return 1 if self.failures else 0
+
+
+class PredictionAdapter(Protocol):
+    """Backend-specific work hidden behind the prediction-batch seam."""
+
+    def configuration_for(self, job: PredictionJob) -> Any:
+        ...
+
+    def setup(self, configuration: Any) -> Any:
+        ...
+
+    def predict(self, session: Any, job: PredictionJob) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class PredictionBatch:
+    """An ordered collection of independent prediction jobs."""
+
+    jobs: Tuple[PredictionJob, ...]
+
+    def _validate(self) -> None:
+        seen_job_ids = set()
+        seen_output_directories = set()
+        for job in self.jobs:
+            if job.job_id in seen_job_ids:
+                raise PredictionBatchError(f"Duplicate job_id: {job.job_id}")
+            seen_job_ids.add(job.job_id)
+
+            output_directory = job.output_directory.resolve()
+            if output_directory in seen_output_directories:
+                raise PredictionBatchError(
+                    f"Duplicate output_directory: {output_directory}"
+                )
+            seen_output_directories.add(output_directory)
+
+    def run(self, adapter: PredictionAdapter) -> PredictionBatchSummary:
+        """Run the batch through one prediction adapter session."""
+        self._validate()
+        if not self.jobs:
+            raise PredictionBatchError("A prediction batch must contain at least one job")
+
+        runnable_jobs = []
+        indexed_failures = []
+        for position, job in enumerate(self.jobs):
+            try:
+                configuration = adapter.configuration_for(job)
+            except Exception as exc:
+                indexed_failures.append(
+                    (position, PredictionFailure(job.job_id, str(exc), exc))
+                )
+            else:
+                runnable_jobs.append((position, job, configuration))
+
+        if not runnable_jobs:
+            return PredictionBatchSummary(
+                (), tuple(failure for _, failure in indexed_failures)
+            )
+
+        configuration = runnable_jobs[0][2]
+        if any(candidate != configuration for _, _, candidate in runnable_jobs[1:]):
+            raise PredictionBatchError(
+                "Prediction batch contains heterogeneous backend/model configurations"
+            )
+
+        session = adapter.setup(configuration)
+        completed = []
+        for position, job, _ in runnable_jobs:
+            try:
+                adapter.predict(session, job)
+            except Exception as exc:
+                indexed_failures.append(
+                    (position, PredictionFailure(job.job_id, str(exc), exc))
+                )
+            else:
+                completed.append(job.job_id)
+        indexed_failures.sort(key=lambda item: item[0])
+        return PredictionBatchSummary(
+            tuple(completed), tuple(failure for _, failure in indexed_failures)
+        )
+
+    @classmethod
+    def from_jsonl(cls, manifest_path: PathLike) -> "PredictionBatch":
+        manifest = Path(manifest_path).expanduser().resolve()
+        jobs = []
+        with manifest.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                if not raw_line.strip():
+                    continue
+                try:
+                    record = json.loads(raw_line)
+                except json.JSONDecodeError as exc:
+                    raise PredictionBatchError(
+                        f"Invalid JSON on manifest line {line_number}: {exc.msg}"
+                    ) from exc
+                if not isinstance(record, dict):
+                    raise PredictionBatchError(
+                        f"Manifest line {line_number} must be a JSON object"
+                    )
+                expected_fields = {"job_id", "input", "output_directory"}
+                if set(record) != expected_fields:
+                    raise PredictionBatchError(
+                        f"Manifest line {line_number} must contain exactly "
+                        f"{sorted(expected_fields)}"
+                    )
+                for field in expected_fields:
+                    value = record[field]
+                    if not isinstance(value, str) or not value.strip():
+                        raise PredictionBatchError(
+                            f"Manifest line {line_number} field {field!r} must be a "
+                            "non-empty string"
+                        )
+                output_directory = Path(record["output_directory"]).expanduser()
+                if not output_directory.is_absolute():
+                    output_directory = manifest.parent / output_directory
+                input_value = record["input"]
+                input_path = Path(input_value).expanduser()
+                if input_path.is_absolute():
+                    input_value = os.fspath(input_path.resolve())
+                else:
+                    manifest_relative_input = manifest.parent / input_path
+                    if manifest_relative_input.exists():
+                        input_value = os.fspath(manifest_relative_input.resolve())
+                jobs.append(
+                    PredictionJob(
+                        job_id=record["job_id"],
+                        input=input_value,
+                        output_directory=output_directory.resolve(),
+                    )
+                )
+        return cls(tuple(jobs))
+
+
+@dataclass(frozen=True)
+class _AlphaPulldownSession:
+    configuration: Dict[str, Any]
+    backend_values: Dict[str, Any]
+
+
+class PreparedPredictionAdapter:
+    """Adapter for the already-parsed invocation used by the legacy command."""
+
+    def __init__(
+        self,
+        *,
+        backend: Any,
+        fold_backend: str,
+        objects_to_model: list,
+        model_flags: Dict[str, Any],
+        postprocess_flags: Dict[str, Any],
+        random_seed: Any,
+    ) -> None:
+        self._backend = backend
+        self._fold_backend = fold_backend
+        self._objects_to_model = objects_to_model
+        self._model_flags = model_flags
+        self._postprocess_flags = postprocess_flags
+        self._requested_random_seed = random_seed
+
+    def configuration_for(self, job: PredictionJob) -> Dict[str, Any]:
+        del job
+        return self._model_flags
+
+    def setup(self, configuration: Dict[str, Any]) -> _AlphaPulldownSession:
+        self._backend.change_backend(backend_name=self._fold_backend)
+        return _AlphaPulldownSession(
+            dict(configuration), self._backend.setup(**configuration)
+        )
+
+    def _random_seed(self, session: _AlphaPulldownSession) -> int:
+        if self._requested_random_seed is not None:
+            return self._requested_random_seed
+        if self._fold_backend == "alphafold2":
+            count = len(session.backend_values["model_runners"])
+            return random.randrange(sys.maxsize // count)
+        if self._fold_backend == "alphafold3":
+            return random.randrange(2**32 - 1)
+        return random.randrange(sys.maxsize)
+
+    def predict(self, session: _AlphaPulldownSession, job: PredictionJob) -> None:
+        del job
+        predicted_jobs = self._backend.predict(
+            **session.backend_values,
+            objects_to_model=self._objects_to_model,
+            random_seed=self._random_seed(session),
+            **session.configuration,
+        )
+        for predicted_job in predicted_jobs:
+            self._backend.postprocess(
+                **self._postprocess_flags,
+                multimeric_object=predicted_job["object"],
+                prediction_results=predicted_job["prediction_results"],
+                output_dir=predicted_job["output_dir"],
+            )
+
+
+class AlphaPulldownPredictionAdapter:
+    """Adapter from prediction jobs to AlphaPulldown's folding backends."""
+
+    def __init__(self, prediction_flags: Any, *, backend: Any) -> None:
+        self._flags = prediction_flags
+        self._backend = backend
+        self._parsed_jobs: Dict[str, Tuple[list, Tuple[str, ...]]] = {}
+
+    def _base_model_flags(self) -> Dict[str, Any]:
+        flags = self._flags
+        return {
+            "model_name": "monomer_ptm",
+            "num_cycle": flags.num_cycle,
+            "model_dir": flags.data_directory,
+            "num_predictions_per_model": flags.num_predictions_per_model,
+            "crosslinks": flags.crosslinks,
+            "desired_num_res": flags.desired_num_res,
+            "desired_num_msa": flags.desired_num_msa,
+            "skip_templates": flags.skip_templates,
+            "allow_resume": flags.allow_resume,
+            "num_diffusion_samples": flags.num_diffusion_samples,
+            "num_recycles": flags.num_recycles,
+            "return_embeddings": flags.save_embeddings,
+            "return_distogram": flags.save_distogram,
+            "flash_attention_implementation": flags.flash_attention_implementation,
+            "buckets": flags.buckets,
+            "jax_compilation_cache_dir": flags.jax_compilation_cache_dir,
+            "features_directory": flags.features_directory,
+            "num_seeds": flags.num_seeds,
+            "debug_templates": flags.debug_templates,
+            "debug_msas": flags.debug_msas,
+            "dropout": flags.dropout,
+        }
+
+    def _postprocess_flags(self) -> Dict[str, Any]:
+        flags = self._flags
+        return {
+            "compress_pickles": flags.compress_result_pickles,
+            "remove_pickles": flags.remove_result_pickles,
+            "remove_keys_from_pickles": flags.remove_keys_from_pickles,
+            "storage_mode": flags.storage_mode,
+            "use_gpu_relax": flags.use_gpu_relax,
+            "models_to_relax": flags.models_to_relax,
+            "relax_best_score_threshold": flags.relax_best_score_threshold,
+            "features_directory": flags.features_directory,
+            "convert_to_modelcif": flags.convert_to_modelcif,
+        }
+
+    def configuration_for(self, job: PredictionJob) -> Dict[str, Any]:
+        from alphapulldown.utils.modelling_setup import parse_fold
+
+        feature_directories = [str(path) for path in self._flags.features_directory]
+        input_path = Path(job.input)
+        if input_path.is_absolute() and input_path.is_file():
+            input_parent = os.fspath(input_path.parent)
+            feature_directories = [
+                input_parent,
+                *(path for path in feature_directories if path != input_parent),
+            ]
+        parsed = parse_fold(
+            [job.input],
+            feature_directories,
+            self._flags.protein_delimiter,
+        )
+        self._parsed_jobs[job.job_id] = (parsed, tuple(feature_directories))
+
+        model_flags = self._base_model_flags()
+        if self._flags.fold_backend == "alphalink":
+            model_flags["model_name"] = "multimer_af2_crop"
+        elif self._flags.fold_backend == "alphafold2":
+            protein_counts = [
+                sum(1 for entry in fold if "json_input" not in entry)
+                for fold in parsed
+            ]
+            if any(count > 1 for count in protein_counts):
+                model_flags.update(
+                    {
+                        "model_name": "multimer",
+                        "msa_depth_scan": self._flags.msa_depth_scan,
+                        "model_names_custom": self._flags.model_names,
+                        "msa_depth": self._flags.msa_depth,
+                    }
+                )
+        return model_flags
+
+    def setup(self, configuration: Dict[str, Any]) -> _AlphaPulldownSession:
+        self._backend.change_backend(backend_name=self._flags.fold_backend)
+        backend_values = self._backend.setup(**configuration)
+        return _AlphaPulldownSession(dict(configuration), backend_values)
+
+    def _random_seed(self, session: _AlphaPulldownSession) -> int:
+        if self._flags.random_seed is not None:
+            return self._flags.random_seed
+        if self._flags.fold_backend == "alphafold2":
+            model_count = len(session.backend_values["model_runners"])
+            return random.randrange(sys.maxsize // model_count)
+        if self._flags.fold_backend == "alphafold3":
+            return random.randrange(2**32 - 1)
+        return random.randrange(sys.maxsize)
+
+    def _prepare_protein_object(self, interactors: list, output_dir: str):
+        from alphapulldown.objects import ChoppedObject, MonomericObject, MultimericObject
+
+        flags = self._flags
+        if (
+            len(interactors) > 1
+            and flags.pair_msa
+            and any(getattr(interactor, "skip_msa", False) for interactor in interactors)
+        ):
+            raise ValueError(
+                "--skip_msa generates query-only MSAs and cannot be combined with "
+                "--pair_msa=True. Re-run structure prediction with --pair_msa=False."
+            )
+
+        if len(interactors) > 1:
+            object_to_model = MultimericObject(
+                interactors=interactors,
+                pair_msa=flags.pair_msa,
+                multimeric_template=flags.multimeric_template,
+                multimeric_template_meta_data=flags.description_file,
+                multimeric_template_dir=flags.path_to_mmt,
+                threshold_clashes=flags.threshold_clashes,
+                hb_allowance=flags.hb_allowance,
+                plddt_threshold=flags.plddt_threshold,
+            )
+            if flags.save_features_for_multimeric_object:
+                with open(
+                    os.path.join(output_dir, "multimeric_object_features.pkl"), "wb"
+                ) as handle:
+                    pickle.dump(MultimericObject.feature_dict, handle)
+        else:
+            object_to_model = interactors[0]
+            object_to_model.input_seqs = [object_to_model.sequence]
+
+        if flags.use_ap_style:
+            oligos = object_to_model.description.split("_and_")
+            if len(oligos) == len(set(oligos)):
+                output_dir = os.path.join(output_dir, object_to_model.description)
+            else:
+                fragments = []
+                for oligo in dict.fromkeys(oligos):
+                    count = oligos.count(oligo)
+                    fragments.append(oligo if count == 1 else f"{oligo}_homo_{count}er")
+                output_dir = os.path.join(output_dir, "_and_".join(fragments))
+
+        if len(output_dir) > 4096:
+            from absl import logging
+
+            logging.warning(
+                f"Output directory path is too long: {output_dir}."
+                "Please use a shorter path with --output_directory."
+            )
+        os.makedirs(output_dir, exist_ok=True)
+
+        for interactor in interactors:
+            metadata_files = []
+            if isinstance(interactor, ChoppedObject):
+                description = interactor.monomeric_description
+            elif isinstance(interactor, MonomericObject):
+                description = interactor.description
+            else:
+                continue
+            for feature_dir in flags.features_directory:
+                metadata_files.extend(
+                    glob.glob(
+                        os.path.join(
+                            feature_dir, f"{description}_feature_metadata_*.json*"
+                        )
+                    )
+                )
+            if not metadata_files:
+                continue
+            latest = max(metadata_files, key=os.path.getmtime)
+            destination = os.path.join(output_dir, os.path.basename(latest))
+            if latest.endswith(".json.xz"):
+                with lzma.open(latest, "rb") as source, open(
+                    destination[:-3], "wb"
+                ) as target:
+                    target.write(source.read())
+            else:
+                shutil.copyfile(latest, destination)
+        return object_to_model, output_dir
+
+    def _objects_to_model(self, job: PredictionJob) -> list:
+        from alphapulldown.utils.modelling_setup import (
+            create_custom_info,
+            create_interactors,
+        )
+        from alphapulldown.utils.output_paths import (
+            resolve_af3_combined_json_output_dir,
+            resolve_af3_json_output_dir,
+        )
+
+        parsed, feature_directories = self._parsed_jobs.pop(job.job_id)
+        all_interactors = create_interactors(
+            create_custom_info(parsed), feature_directories
+        )
+        objects_to_model = []
+        for interactors in all_interactors:
+            if not interactors:
+                continue
+            json_dicts = [
+                value
+                for value in interactors
+                if isinstance(value, dict) and "json_input" in value
+            ]
+            protein_objects = [
+                value
+                for value in interactors
+                if not (isinstance(value, dict) and "json_input" in value)
+            ]
+            output_dir = os.fspath(job.output_directory)
+            if protein_objects:
+                protein_object, actual_output_dir = self._prepare_protein_object(
+                    protein_objects, output_dir
+                )
+                objects_to_model.append(
+                    {"object": protein_object, "output_dir": actual_output_dir}
+                )
+                json_output_dir = actual_output_dir
+            elif len(json_dicts) > 1:
+                json_output_dir = resolve_af3_combined_json_output_dir(
+                    json_dicts,
+                    output_dir,
+                    use_ap_style=self._flags.use_ap_style,
+                )
+            else:
+                json_output_dir = None
+
+            for json_dict in json_dicts:
+                current_output_dir = json_output_dir
+                if current_output_dir is None:
+                    current_output_dir = resolve_af3_json_output_dir(
+                        json_dict["json_input"],
+                        output_dir,
+                        use_ap_style=self._flags.use_ap_style,
+                        shared_output_root=False,
+                    )
+                objects_to_model.append(
+                    {"object": json_dict, "output_dir": current_output_dir}
+                )
+
+        return objects_to_model
+
+    def predict(self, session: _AlphaPulldownSession, job: PredictionJob) -> None:
+        objects_to_model = self._objects_to_model(job)
+        predicted_jobs = self._backend.predict(
+            **session.backend_values,
+            objects_to_model=objects_to_model,
+            random_seed=self._random_seed(session),
+            **session.configuration,
+        )
+        postprocess_flags = self._postprocess_flags()
+        for predicted_job in predicted_jobs:
+            self._backend.postprocess(
+                **postprocess_flags,
+                multimeric_object=predicted_job["object"],
+                prediction_results=predicted_job["prediction_results"],
+                output_dir=predicted_job["output_dir"],
+            )

--- a/alphapulldown/prediction_batch.py
+++ b/alphapulldown/prediction_batch.py
@@ -3,14 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import glob
 import json
-import lzma
 import os
 from pathlib import Path
-import pickle
 import random
-import shutil
 import sys
 from typing import Any, Dict, Optional, Protocol, Tuple, Union
 
@@ -401,87 +397,9 @@ class AlphaPulldownPredictionAdapter:
         return random.randrange(sys.maxsize)
 
     def _prepare_protein_object(self, interactors: list, output_dir: str):
-        from alphapulldown.objects import ChoppedObject, MonomericObject, MultimericObject
+        from alphapulldown.fold_preparation import prepare_fold
 
-        flags = self._flags
-        if (
-            len(interactors) > 1
-            and flags.pair_msa
-            and any(getattr(interactor, "skip_msa", False) for interactor in interactors)
-        ):
-            raise ValueError(
-                "--skip_msa generates query-only MSAs and cannot be combined with "
-                "--pair_msa=True. Re-run structure prediction with --pair_msa=False."
-            )
-
-        if len(interactors) > 1:
-            object_to_model = MultimericObject(
-                interactors=interactors,
-                pair_msa=flags.pair_msa,
-                multimeric_template=flags.multimeric_template,
-                multimeric_template_meta_data=flags.description_file,
-                multimeric_template_dir=flags.path_to_mmt,
-                threshold_clashes=flags.threshold_clashes,
-                hb_allowance=flags.hb_allowance,
-                plddt_threshold=flags.plddt_threshold,
-            )
-            if flags.save_features_for_multimeric_object:
-                with open(
-                    os.path.join(output_dir, "multimeric_object_features.pkl"), "wb"
-                ) as handle:
-                    pickle.dump(MultimericObject.feature_dict, handle)
-        else:
-            object_to_model = interactors[0]
-            object_to_model.input_seqs = [object_to_model.sequence]
-
-        if flags.use_ap_style:
-            oligos = object_to_model.description.split("_and_")
-            if len(oligos) == len(set(oligos)):
-                output_dir = os.path.join(output_dir, object_to_model.description)
-            else:
-                fragments = []
-                for oligo in dict.fromkeys(oligos):
-                    count = oligos.count(oligo)
-                    fragments.append(oligo if count == 1 else f"{oligo}_homo_{count}er")
-                output_dir = os.path.join(output_dir, "_and_".join(fragments))
-
-        if len(output_dir) > 4096:
-            from absl import logging
-
-            logging.warning(
-                f"Output directory path is too long: {output_dir}."
-                "Please use a shorter path with --output_directory."
-            )
-        os.makedirs(output_dir, exist_ok=True)
-
-        for interactor in interactors:
-            metadata_files = []
-            if isinstance(interactor, ChoppedObject):
-                description = interactor.monomeric_description
-            elif isinstance(interactor, MonomericObject):
-                description = interactor.description
-            else:
-                continue
-            for feature_dir in flags.features_directory:
-                metadata_files.extend(
-                    glob.glob(
-                        os.path.join(
-                            feature_dir, f"{description}_feature_metadata_*.json*"
-                        )
-                    )
-                )
-            if not metadata_files:
-                continue
-            latest = max(metadata_files, key=os.path.getmtime)
-            destination = os.path.join(output_dir, os.path.basename(latest))
-            if latest.endswith(".json.xz"):
-                with lzma.open(latest, "rb") as source, open(
-                    destination[:-3], "wb"
-                ) as target:
-                    target.write(source.read())
-            else:
-                shutil.copyfile(latest, destination)
-        return object_to_model, output_dir
+        return prepare_fold(interactors, output_dir, self._flags)
 
     def _objects_to_model(self, job: PredictionJob) -> list:
         from alphapulldown.utils.modelling_setup import (

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -9,6 +9,8 @@
 """
 import pickle
 
+import jax
+gpus = jax.local_devices(backend='gpu')
 from absl import flags, app
 import os
 from os import makedirs

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -252,6 +252,7 @@ def _validate_flags_for_backend(backend_name: str) -> None:
         'description_file', 'path_to_mmt', 'threshold_clashes', 'hb_allowance',
         'plddt_threshold', 'desired_num_res', 'desired_num_msa',
         'benchmark', 'model_preset', 'use_ap_style', 'use_gpu_relax', 'dropout',
+        'jax_compilation_cache_dir',
     }
     alphalink_extra = {'crosslinks'}
     af3_flags = {

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -339,109 +339,17 @@ def predict_structure(
         raise summary.failures[0].exception
 
 def pre_modelling_setup(
-    interactors : List[Union[MonomericObject, ChoppedObject]], output_dir) -> Tuple[Union[MultimericObject,MonomericObject, ChoppedObject], str]:
+    interactors: List[Union[MonomericObject, ChoppedObject]], output_dir
+) -> Tuple[Union[MultimericObject, MonomericObject, ChoppedObject], str]:
+    """Build the object to model for one fold and prepare its output directory.
+
+    Delegates to the shared fold-preparation module so this command and the resident
+    batch command cannot drift apart.
     """
-    A function that sets up objects to be modelled and handles output directory preparation.
+    from alphapulldown.fold_preparation import prepare_fold
 
-    Args:
-    interactors: A list of MonomericObject or ChoppedObject. If len(interactors) == 1, 
-    that means a monomeric modelling job should be done. Otherwise, it will be a multimeric modelling job
-    output_dir: base output directory
+    return prepare_fold(interactors, output_dir, FLAGS)
 
-    Return:
-    A MultimericObject or MonomericObject
-    output_directory for this particular modelling job
-    """
-    if (
-        len(interactors) > 1
-        and FLAGS.pair_msa
-        and any(getattr(interactor, "skip_msa", False) for interactor in interactors)
-    ):
-        raise ValueError(
-            "--skip_msa generates query-only MSAs and cannot be combined with "
-            "--pair_msa=True. Re-run structure prediction with --pair_msa=False."
-        )
-
-    if len(interactors) > 1:
-        # this means it's going to be a MultimericObject
-        object_to_model = MultimericObject(
-            interactors=interactors,
-            pair_msa=FLAGS.pair_msa,
-            multimeric_template=FLAGS.multimeric_template,
-            multimeric_template_meta_data=FLAGS.description_file,
-            multimeric_template_dir=FLAGS.path_to_mmt,
-            threshold_clashes=FLAGS.threshold_clashes,
-            hb_allowance=FLAGS.hb_allowance,
-            plddt_threshold=FLAGS.plddt_threshold,
-        )
-        if FLAGS.save_features_for_multimeric_object:
-            pickle.dump(MultimericObject.feature_dict, open(join(output_dir, "multimeric_object_features.pkl"), "wb"))
-    else:
-        # means it's going to be a MonomericObject or a ChoppedObject
-        object_to_model= interactors[0]
-        object_to_model.input_seqs = [object_to_model.sequence]
-
-    if FLAGS.use_ap_style:
-        list_oligo = object_to_model.description.split("_and_")
-        if len(list_oligo) == len(set(list_oligo)) : #no homo-oligomer
-           output_dir = join(output_dir, object_to_model.description)
-        else :
-            old_output_dir = output_dir
-            for oligo in list(dict.fromkeys(list_oligo)) :
-                number_oligo = list_oligo.count(oligo)
-                if output_dir == old_output_dir :
-                    if number_oligo != 1 :
-                        output_dir += f"/{oligo}_homo_{number_oligo}er"
-                    else :
-                        output_dir += f"/{oligo}"
-                else :
-                    if number_oligo != 1 :
-                        output_dir += f"_and_{oligo}_homo_{number_oligo}er"
-                    else :
-                        output_dir += f"_and_{oligo}"
-    if len(output_dir) > 4096: #max path length for most filesystems
-        logging.warning(f"Output directory path is too long: {output_dir}."
-                        "Please use a shorter path with --output_directory.")
-    
-    # Create parent directories first
-    parent_dir = os.path.dirname(output_dir)
-    if parent_dir:
-        os.makedirs(parent_dir, exist_ok=True)
-    os.makedirs(output_dir, exist_ok=True)
-    
-    # Copy features metadata to output directory
-    for interactor in interactors:
-        for feature_dir in FLAGS.features_directory:
-            # meta.json is named the same way as the pickle file
-            if isinstance(interactor, ChoppedObject):
-                description = interactor.monomeric_description
-            elif isinstance(interactor, MonomericObject):
-                description = interactor.description
-            meta_json = glob.glob(
-                join(feature_dir, f"{description}_feature_metadata_*.json*")
-            )
-        if meta_json:
-            # sort by modification time to take the latest
-            meta_json.sort(key=os.path.getmtime, reverse=True)
-
-            for feature_json in meta_json:
-                output_path = join(output_dir, basename(feature_json))
-
-                if feature_json.endswith(".json.xz"):
-                    # Decompress before copying
-                    decompressed_path = output_path.rstrip(".xz")
-                    logging.info(f"Decompressing {feature_json} to {decompressed_path}")
-
-                    with lzma.open(feature_json, "rb") as xz_file, open(decompressed_path, "wb") as json_file:
-                        json_file.write(xz_file.read())
-                else:
-                    # Copy without decompression
-                    logging.info(f"Copying {feature_json} to {output_dir}")
-                    shutil.copyfile(feature_json, output_path)
-        else:
-            logging.warning(f"No feature metadata found for {interactor.description} in {feature_dir}")
-
-    return object_to_model, output_dir
 
 def main(argv):
     _validate_flags_for_backend(FLAGS.fold_backend)

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -9,8 +9,6 @@
 """
 import pickle
 
-import jax
-gpus = jax.local_devices(backend='gpu')
 from absl import flags, app
 import os
 from os import makedirs

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -22,6 +22,7 @@ import shutil
 import lzma
 import random
 import sys
+from alphapulldown import inference_flags
 from alphapulldown.folding_backend import backend
 from alphapulldown.folding_backend.alphafold2_backend import ModelsToRelax
 from alphapulldown.objects import MultimericObject, MonomericObject, ChoppedObject
@@ -232,65 +233,26 @@ flags.DEFINE_boolean(
 FLAGS = flags.FLAGS
 
 def _validate_flags_for_backend(backend_name: str) -> None:
-    """
-    Fail fast if user passed flags not supported by the selected backend.
-    """
-    # Flags common to all backends
-    common_flags = {
-        'input', 'output_directory', 'data_directory', 'features_directory',
-        'protein_delimiter', 'fold_backend', 'random_seed', 'storage_mode',
-    }
+    """Fail fast if the user passed flags the selected backend does not accept."""
+    from alphapulldown.inference_flags import unsupported_flags
 
-    # Backend-specific flags
-    af2_like_flags = {
-        'compress_result_pickles', 'remove_result_pickles', 'models_to_relax',
-        'relax_best_score_threshold', 'remove_keys_from_pickles',
-        'convert_to_modelcif', 'allow_resume',
-        'num_cycle', 'num_predictions_per_model', 'pair_msa',
-        'save_features_for_multimeric_object', 'skip_templates',
-        'msa_depth_scan', 'multimeric_template', 'model_names', 'msa_depth',
-        'description_file', 'path_to_mmt', 'threshold_clashes', 'hb_allowance',
-        'plddt_threshold', 'desired_num_res', 'desired_num_msa',
-        'benchmark', 'model_preset', 'use_ap_style', 'use_gpu_relax', 'dropout',
-        'jax_compilation_cache_dir',
-    }
-    alphalink_extra = {'crosslinks'}
-    af3_flags = {
-        'jax_compilation_cache_dir', 'buckets', 'flash_attention_implementation',
-        'num_diffusion_samples', 'num_seeds', 'debug_templates', 'debug_msas',
-        'num_recycles', 'save_embeddings', 'save_distogram', 'use_ap_style',
-        'convert_to_modelcif',
-    }
-
-    allowed_by_backend = {
-        'alphafold2': common_flags | af2_like_flags,
-        'alphalink': common_flags | af2_like_flags | alphalink_extra,
-        'alphafold3': common_flags | af3_flags,
-    }
-
-    allowed = allowed_by_backend.get(backend_name)
-    if allowed is None:
-        return
-
-    # Consider only flags defined in this module
     try:
         key_flags = FLAGS.get_key_flags_for_module(_sys.modules[__name__])
         module_flag_names = {kf.name for kf in key_flags}
     except Exception:
-        # Fallback: include all flags; still safe, but may include ABSL built-ins
         module_flag_names = set(FLAGS)
 
     explicitly_set = {
         name for name in module_flag_names
         if name in FLAGS and FLAGS[name].present
     }
-
-    disallowed = explicitly_set - allowed
+    disallowed = unsupported_flags(backend_name, explicitly_set)
     if disallowed:
         raise ValueError(
             f"The following flags are not supported by backend '{backend_name}': "
-            f"{sorted(disallowed)}"
+            f"{disallowed}"
         )
+
 
 def predict_structure(
     objects_to_model: List[Dict[str, Union[MultimericObject, MonomericObject, ChoppedObject, str]]],
@@ -370,45 +332,13 @@ def main(argv):
     shared_output_root = len(FLAGS.output_directory) == 1 and n > 1
 
     # Define default model and postprocess flags
-    default_model_flags = {
-        "model_name": "monomer_ptm",
-        "num_cycle": FLAGS.num_cycle,
-        "model_dir": FLAGS.data_directory,
-        "num_predictions_per_model": FLAGS.num_predictions_per_model,
-        "crosslinks": FLAGS.crosslinks,
-        "desired_num_res": FLAGS.desired_num_res,
-        "desired_num_msa": FLAGS.desired_num_msa,
-        "skip_templates": FLAGS.skip_templates,
-        "allow_resume": FLAGS.allow_resume,
-        "num_diffusion_samples": FLAGS.num_diffusion_samples,
-        "num_recycles": FLAGS.num_recycles,
-        "return_embeddings": FLAGS.save_embeddings,
-        "return_distogram": FLAGS.save_distogram,
-        "flash_attention_implementation": FLAGS.flash_attention_implementation,
-        "buckets": FLAGS.buckets,
-        "jax_compilation_cache_dir": FLAGS.jax_compilation_cache_dir,
-        "features_directory": FLAGS.features_directory,
-        "num_seeds": FLAGS.num_seeds,
-        "debug_templates": FLAGS.debug_templates,
-        "debug_msas": FLAGS.debug_msas,
-        "dropout": FLAGS.dropout,
-    }
-    
+    default_model_flags = inference_flags.model_flags(FLAGS)
+
     # Override model name for AlphaLink backend
     if FLAGS.fold_backend == "alphalink":
         default_model_flags["model_name"] = "multimer_af2_crop"
 
-    default_postprocess_flags = {
-        "compress_pickles": FLAGS.compress_result_pickles,
-        "remove_pickles": FLAGS.remove_result_pickles,
-        "remove_keys_from_pickles": FLAGS.remove_keys_from_pickles,
-        "storage_mode": FLAGS.storage_mode,
-        "use_gpu_relax": FLAGS.use_gpu_relax,
-        "models_to_relax": FLAGS.models_to_relax,
-        "relax_best_score_threshold": FLAGS.relax_best_score_threshold,
-        "features_directory": FLAGS.features_directory,
-        "convert_to_modelcif": FLAGS.convert_to_modelcif
-    }
+    default_postprocess_flags = inference_flags.postprocess_flags(FLAGS)
 
     # Prepare the list of jobs
     objects_to_model = []

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -313,37 +313,29 @@ def predict_structure(
     fold_backend : str, optional
         Backend used for folding, defaults to alphafold2.
     """
-    backend.change_backend(backend_name=fold_backend)
-    model_runners_and_configs = backend.setup(**model_flags)
-    if FLAGS.random_seed is not None:
-        random_seed = FLAGS.random_seed
-    else:
-        if fold_backend == 'alphafold2':
-            random_seed = random.randrange(sys.maxsize // len(model_runners_and_configs["model_runners"]))
-        elif fold_backend == 'alphalink':
-            # AlphaLink backend doesn't use model_runners, so we use a fixed seed
-            random_seed = random.randrange(sys.maxsize)
-        elif fold_backend=='alphafold3':
-            random_seed = random.randrange(2**32 - 1)
-        else:
-            random_seed = random.randrange(sys.maxsize)
-    predicted_jobs = backend.predict(
-        **model_runners_and_configs,
-        objects_to_model=objects_to_model,
-        random_seed=random_seed,
-        **model_flags
+    from pathlib import Path
+
+    from alphapulldown.prediction_batch import (
+        PredictionBatch,
+        PredictionJob,
+        PreparedPredictionAdapter,
     )
 
-    for predicted_job in predicted_jobs:
-        object_to_model = predicted_job['object']
-        prediction_results = predicted_job['prediction_results']
-        output_dir = predicted_job['output_dir']
-        backend.postprocess(
-            **postprocess_flags,
-            multimeric_object=object_to_model,
-            prediction_results=prediction_results,
-            output_dir=output_dir
+    output_hint = objects_to_model[0]["output_dir"] if objects_to_model else "."
+    summary = PredictionBatch(
+        (PredictionJob("legacy-invocation", "", Path(output_hint)),)
+    ).run(
+        PreparedPredictionAdapter(
+            backend=backend,
+            fold_backend=fold_backend,
+            objects_to_model=objects_to_model,
+            model_flags=model_flags,
+            postprocess_flags=postprocess_flags,
+            random_seed=FLAGS.random_seed,
         )
+    )
+    if summary.failures:
+        raise summary.failures[0].exception
 
 def pre_modelling_setup(
     interactors : List[Union[MonomericObject, ChoppedObject]], output_dir) -> Tuple[Union[MultimericObject,MonomericObject, ChoppedObject], str]:

--- a/alphapulldown/scripts/run_structure_prediction_batch.py
+++ b/alphapulldown/scripts/run_structure_prediction_batch.py
@@ -5,7 +5,7 @@ from absl import app, flags, logging
 
 from alphapulldown.prediction_batch import (
     AlphaPulldownPredictionAdapter,
-    PredictionBatch,
+    execute_prediction_manifest,
 )
 from alphapulldown.scripts import run_structure_prediction as prediction_command
 
@@ -22,20 +22,21 @@ FLAGS = flags.FLAGS
 def main(argv) -> None:
     del argv
     prediction_command._validate_flags_for_backend(FLAGS.fold_backend)
-    batch = PredictionBatch.from_jsonl(FLAGS.manifest)
-    summary = batch.run(
-        AlphaPulldownPredictionAdapter(FLAGS, backend=prediction_command.backend)
+    outcome = execute_prediction_manifest(
+        FLAGS.manifest,
+        AlphaPulldownPredictionAdapter(FLAGS, backend=prediction_command.backend),
     )
 
-    logging.info(
-        "Prediction batch summary: %d completed, %d failed",
-        len(summary.completed_job_ids),
-        len(summary.failures),
-    )
-    for failure in summary.failures:
-        logging.error("Prediction job %s failed: %s", failure.job_id, failure.message)
-    if summary.failures:
-        raise SystemExit(summary.exit_code)
+    if outcome.rejection is not None:
+        logging.error("Prediction batch rejected: %s", outcome.rejection)
+    if outcome.summary is not None:
+        for failure in outcome.summary.failures:
+            logging.error(
+                "Prediction job %s failed: %s", failure.job_id, failure.message
+            )
+    logging.info(outcome.summary_message)
+    if outcome.exit_code:
+        raise SystemExit(outcome.exit_code)
 
 
 if __name__ == "__main__":

--- a/alphapulldown/scripts/run_structure_prediction_batch.py
+++ b/alphapulldown/scripts/run_structure_prediction_batch.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Run independent AlphaPulldown folds through one resident model session."""
+
+from absl import app, flags, logging
+
+from alphapulldown.prediction_batch import (
+    AlphaPulldownPredictionAdapter,
+    PredictionBatch,
+)
+from alphapulldown.scripts import run_structure_prediction as prediction_command
+
+
+flags.DEFINE_string(
+    "manifest",
+    None,
+    "JSONL manifest containing independent prediction jobs.",
+)
+
+FLAGS = flags.FLAGS
+
+
+def main(argv) -> None:
+    del argv
+    prediction_command._validate_flags_for_backend(FLAGS.fold_backend)
+    batch = PredictionBatch.from_jsonl(FLAGS.manifest)
+    summary = batch.run(
+        AlphaPulldownPredictionAdapter(FLAGS, backend=prediction_command.backend)
+    )
+
+    logging.info(
+        "Prediction batch summary: %d completed, %d failed",
+        len(summary.completed_job_ids),
+        len(summary.failures),
+    )
+    for failure in summary.failures:
+        logging.error("Prediction job %s failed: %s", failure.job_id, failure.message)
+    if summary.failures:
+        raise SystemExit(summary.exit_code)
+
+
+if __name__ == "__main__":
+    flags.mark_flag_as_required("manifest")
+    flags.mark_flag_as_required("data_directory")
+    flags.mark_flag_as_required("features_directory")
+    app.run(main)

--- a/docker/alphafold2.dockerfile
+++ b/docker/alphafold2.dockerfile
@@ -56,7 +56,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     set -eux; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates curl bzip2 tzdata openssh-client; \
+      ca-certificates curl bzip2 tzdata; \
     rm -rf /var/lib/apt/lists/*
 
 # Micromamba bootstrap (smaller than Miniforge)
@@ -98,15 +98,11 @@ RUN set -eux; \
 #RUN micromamba run -n base python -m pip install --no-cache-dir "openmm==8.1.1"
 RUN python -m pip install --no-cache-dir "setuptools<82" # setuptools>82 breaks pdbfixer at relaxation
 
-# Clone from repo
-RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh
-RUN ssh-keyscan github.com >> /root/.ssh/known_hosts
-RUN  git clone --recurse-submodules https://github.com/KosinskiLab/AlphaPulldown.git
-WORKDIR AlphaPulldown
-
-#DEBUG
-#WORKDIR /AlphaPulldown
-#COPY . /AlphaPulldown
+# Install the exact checkout supplied as the Docker build context. In particular,
+# pull-request image builds must test the submitted code rather than repository
+# main.
+WORKDIR /AlphaPulldown
+COPY . /AlphaPulldown
 RUN pip install --no-build-isolation .
 # jax takes its CUDA runtime from the nvidia-* wheels, not from the base image, and
 # `jax[cuda12]==0.5.3` puts no floor on them - which version you get depends on when
@@ -131,6 +127,10 @@ RUN pip3 install --upgrade pip --no-cache-dir \
 # this file (conda + pyproject) run BEFORE the jax upgrade so they do not stick; re-pin
 # numpy<2 as the LAST dependency step. jax 0.5.3 runs fine with numpy 1.26.x.
 RUN pip install --no-cache-dir "numpy<2"
+
+# Exercise the installed entry point without requiring a GPU during the build.
+# This catches packaging/import regressions in the exact checkout copied above.
+RUN run_structure_prediction_batch.py --helpshort >/dev/null
 
 # AlphaFold's template code formats a hit's `sum_probs` with %.2f in the error
 # path of `_process_single_hit`, but sum_probs is legitimately None for some hits

--- a/docker/alphafold2.dockerfile
+++ b/docker/alphafold2.dockerfile
@@ -104,6 +104,7 @@ RUN python -m pip install --no-cache-dir "setuptools<82" # setuptools>82 breaks 
 WORKDIR /AlphaPulldown
 COPY . /AlphaPulldown
 RUN pip install --no-build-isolation .
+RUN command -v run_structure_prediction_batch.py
 # jax takes its CUDA runtime from the nvidia-* wheels, not from the base image, and
 # `jax[cuda12]==0.5.3` puts no floor on them - which version you get depends on when
 # the image was built. Blackwell cards (RTX PRO 4500/6000, compute capability 12.0 /
@@ -127,10 +128,6 @@ RUN pip3 install --upgrade pip --no-cache-dir \
 # this file (conda + pyproject) run BEFORE the jax upgrade so they do not stick; re-pin
 # numpy<2 as the LAST dependency step. jax 0.5.3 runs fine with numpy 1.26.x.
 RUN pip install --no-cache-dir "numpy<2"
-
-# Exercise the installed entry point without requiring a GPU during the build.
-# This catches packaging/import regressions in the exact checkout copied above.
-RUN run_structure_prediction_batch.py --helpshort >/dev/null
 
 # AlphaFold's template code formats a hit's `sum_probs` with %.2f in the error
 # path of `_process_single_hit`, but sum_probs is legitimately None for some hits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ script-files = [
   "./alphapulldown/scripts/generate_crosslink_pickle.py",
   "./alphapulldown/scripts/convert_to_modelcif.py",
   "./alphapulldown/scripts/run_structure_prediction.py",
+  "./alphapulldown/scripts/run_structure_prediction_batch.py",
   "./alphapulldown/scripts/truncate_pickles.py",
   "./alphafold/run_alphafold.py",
 ]

--- a/test/unit/test_inference_flags.py
+++ b/test/unit/test_inference_flags.py
@@ -1,0 +1,88 @@
+"""The inference flag set has one home; these pin what that home guarantees."""
+
+import pytest
+
+from alphapulldown import inference_flags
+
+
+class _Flags:
+    """Stand-in for the parsed invocation."""
+
+    def __init__(self, **overrides):
+        defaults = dict(
+            num_cycle=3, data_directory="/weights", num_predictions_per_model=1,
+            crosslinks=None, desired_num_res=None, desired_num_msa=None,
+            skip_templates=False, allow_resume=True, num_diffusion_samples=5,
+            num_recycles=10, save_embeddings=False, save_distogram=False,
+            flash_attention_implementation="triton", buckets=["256"],
+            jax_compilation_cache_dir=None, features_directory=["/features"],
+            num_seeds=None, debug_templates=False, debug_msas=False, dropout=False,
+            fold_backend="alphafold3",
+            compress_result_pickles=False, remove_result_pickles=False,
+            remove_keys_from_pickles=None, storage_mode="default",
+            use_gpu_relax=True, models_to_relax="none",
+            relax_best_score_threshold=None, convert_to_modelcif=True,
+        )
+        defaults.update(overrides)
+        self.__dict__.update(defaults)
+
+
+def test_every_backend_accepts_the_common_flags():
+    for backend, allowed in inference_flags.FLAGS_BY_BACKEND.items():
+        assert inference_flags.COMMON_FLAGS <= allowed, backend
+
+
+def test_af2_only_and_af3_only_flags_are_rejected_by_the_other_backend():
+    assert inference_flags.unsupported_flags("alphafold3", ["allow_resume"]) == [
+        "allow_resume"
+    ]
+    assert inference_flags.unsupported_flags("alphafold2", ["buckets"]) == ["buckets"]
+
+
+def test_jax_compile_cache_is_accepted_by_both_backends():
+    for backend in ("alphafold2", "alphafold3"):
+        assert inference_flags.unsupported_flags(
+            backend, ["jax_compilation_cache_dir"]
+        ) == []
+
+
+def test_convert_to_modelcif_is_accepted_by_both_backends():
+    # The workflow's hand-copied table omitted this and produced a false warning.
+    for backend in ("alphafold2", "alphafold3"):
+        assert inference_flags.unsupported_flags(backend, ["convert_to_modelcif"]) == []
+
+
+def test_unknown_backend_reports_nothing():
+    assert inference_flags.unsupported_flags("boltz", ["anything"]) == []
+
+
+def test_model_flags_names_the_alphalink_model():
+    assert inference_flags.model_flags(_Flags())["model_name"] == "monomer_ptm"
+    alphalink = inference_flags.model_flags(_Flags(fold_backend="alphalink"))
+    assert alphalink["model_name"] == "multimer_af2_crop"
+
+
+def test_built_configuration_is_accepted_by_its_own_validator():
+    inference_flags.validate_model_configuration(inference_flags.model_flags(_Flags()))
+
+
+def test_multimer_extras_are_accepted():
+    configuration = inference_flags.model_flags(_Flags())
+    configuration.update(
+        model_name="multimer", msa_depth_scan=False,
+        model_names_custom=None, msa_depth=None,
+    )
+    inference_flags.validate_model_configuration(configuration)
+
+
+def test_mistyped_configuration_key_is_reported_not_dropped():
+    configuration = inference_flags.model_flags(_Flags())
+    configuration["jax_compilation_cache_dirr"] = "/cache"
+    with pytest.raises(ValueError, match="jax_compilation_cache_dirr"):
+        inference_flags.validate_model_configuration(configuration)
+
+
+def test_postprocess_flags_are_built_from_the_invocation():
+    built = inference_flags.postprocess_flags(_Flags(use_gpu_relax=False))
+    assert built["use_gpu_relax"] is False
+    assert built["compress_pickles"] is False

--- a/test/unit/test_prediction_batch.py
+++ b/test/unit/test_prediction_batch.py
@@ -1,0 +1,436 @@
+import json
+from pathlib import Path
+import pickle
+from types import SimpleNamespace
+
+import pytest
+
+
+def _prediction_flags(tmp_path, backend):
+    return SimpleNamespace(
+        fold_backend=backend,
+        features_directory=[str(tmp_path)],
+        protein_delimiter="+",
+        data_directory="/models",
+        random_seed=7,
+        num_cycle=3,
+        num_predictions_per_model=1,
+        crosslinks=None,
+        desired_num_res=None,
+        desired_num_msa=None,
+        skip_templates=False,
+        allow_resume=True,
+        num_diffusion_samples=5,
+        num_recycles=10,
+        save_embeddings=False,
+        save_distogram=False,
+        flash_attention_implementation="triton",
+        buckets=["64", "128"],
+        jax_compilation_cache_dir=None,
+        num_seeds=None,
+        debug_templates=False,
+        debug_msas=False,
+        dropout=False,
+        compress_result_pickles=False,
+        remove_result_pickles=False,
+        remove_keys_from_pickles=True,
+        storage_mode="vanilla",
+        use_gpu_relax=True,
+        models_to_relax="none",
+        relax_best_score_threshold=None,
+        convert_to_modelcif=False,
+        use_ap_style=False,
+        pair_msa=True,
+        multimeric_template=False,
+        description_file=None,
+        path_to_mmt=None,
+        threshold_clashes=1000,
+        hb_allowance=0.4,
+        plddt_threshold=0,
+        save_features_for_multimeric_object=False,
+        msa_depth_scan=False,
+        model_names=None,
+        msa_depth=None,
+    )
+
+
+def test_manifest_loads_jobs_in_order_and_resolves_output_paths(tmp_path):
+    from alphapulldown.prediction_batch import PredictionBatch
+
+    manifest = tmp_path / "batches" / "small.jsonl"
+    manifest.parent.mkdir()
+    records = [
+        {
+            "job_id": "A_and_B",
+            "input": "A+B",
+            "output_directory": "../predictions/A_and_B",
+        },
+        {
+            "job_id": "C_and_D",
+            "input": "C+D",
+            "output_directory": "../predictions/C_and_D",
+        },
+    ]
+    manifest.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+    batch = PredictionBatch.from_jsonl(manifest)
+
+    assert [job.job_id for job in batch.jobs] == ["A_and_B", "C_and_D"]
+    assert [job.input for job in batch.jobs] == ["A+B", "C+D"]
+    assert [job.output_directory for job in batch.jobs] == [
+        (manifest.parent / "../predictions/A_and_B").resolve(),
+        (manifest.parent / "../predictions/C_and_D").resolve(),
+    ]
+
+
+def test_manifest_resolves_relative_file_input_from_its_parent(tmp_path):
+    from alphapulldown.prediction_batch import PredictionBatch
+
+    manifest = tmp_path / "batch" / "jobs.jsonl"
+    input_path = manifest.parent / "inputs" / "fold.json"
+    input_path.parent.mkdir(parents=True)
+    input_path.write_text("{}", encoding="utf-8")
+    manifest.write_text(
+        json.dumps(
+            {
+                "job_id": "json-fold",
+                "input": "inputs/fold.json",
+                "output_directory": "outputs/json-fold",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    batch = PredictionBatch.from_jsonl(manifest)
+
+    assert batch.jobs[0].input == str(input_path.resolve())
+
+
+def test_manifest_relative_json_is_available_to_the_parser_adapter(tmp_path):
+    from alphapulldown.prediction_batch import (
+        AlphaPulldownPredictionAdapter,
+        PredictionBatch,
+    )
+
+    manifest = tmp_path / "batch" / "jobs.jsonl"
+    manifest.parent.mkdir()
+    (manifest.parent / "fold.json").write_text(
+        json.dumps({"name": "fold", "sequences": [], "modelSeeds": [1]}),
+        encoding="utf-8",
+    )
+    manifest.write_text(
+        json.dumps(
+            {
+                "job_id": "fold",
+                "input": "fold.json",
+                "output_directory": "output",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    unrelated_features = tmp_path / "features"
+    unrelated_features.mkdir()
+    flags = _prediction_flags(unrelated_features, "alphafold3")
+
+    class Backend:
+        def change_backend(self, backend_name):
+            return None
+
+        def setup(self, **kwargs):
+            return {"model_runner": object()}
+
+        def predict(self, **kwargs):
+            entry = kwargs["objects_to_model"][0]
+            yield {
+                "object": entry["object"],
+                "output_dir": entry["output_dir"],
+                "prediction_results": {},
+            }
+
+        def postprocess(self, **kwargs):
+            return None
+
+    summary = PredictionBatch.from_jsonl(manifest).run(
+        AlphaPulldownPredictionAdapter(flags, backend=Backend())
+    )
+
+    assert summary.exit_code == 0
+
+
+@pytest.mark.parametrize("duplicate", ["job_id", "output_directory"])
+def test_invalid_batch_is_rejected_before_backend_setup(tmp_path, duplicate):
+    from alphapulldown.prediction_batch import (
+        PredictionBatch,
+        PredictionBatchError,
+        PredictionJob,
+    )
+
+    first = PredictionJob("job-a", "A+B", (tmp_path / "a").resolve())
+    second = PredictionJob(
+        "job-a" if duplicate == "job_id" else "job-b",
+        "C+D",
+        (tmp_path / ("a" if duplicate == "output_directory" else "b")).resolve(),
+    )
+
+    class RecordingAdapter:
+        def __init__(self):
+            self.setup_calls = 0
+
+        def configuration_for(self, job):
+            return "alphafold3"
+
+        def setup(self, configuration):
+            self.setup_calls += 1
+            return object()
+
+        def predict(self, session, job):
+            return None
+
+    adapter = RecordingAdapter()
+
+    with pytest.raises(PredictionBatchError, match="Duplicate"):
+        PredictionBatch((first, second)).run(adapter)
+
+    assert adapter.setup_calls == 0
+
+
+def test_batch_sets_up_once_and_reports_failures_after_running_remaining_jobs(tmp_path):
+    from alphapulldown.prediction_batch import PredictionBatch, PredictionJob
+
+    jobs = tuple(
+        PredictionJob(job_id, fold, (tmp_path / job_id).resolve())
+        for job_id, fold in (
+            ("first", "A+B"),
+            ("broken", "C+D"),
+            ("last", "E+F"),
+        )
+    )
+
+    class RecordingAdapter:
+        def __init__(self):
+            self.setup_calls = []
+            self.predicted = []
+
+        def configuration_for(self, job):
+            return ("alphafold3", "shared-model-config")
+
+        def setup(self, configuration):
+            self.setup_calls.append(configuration)
+            return "resident-session"
+
+        def predict(self, session, job):
+            assert session == "resident-session"
+            self.predicted.append(job.job_id)
+            if job.job_id == "broken":
+                raise RuntimeError("bad fold")
+
+    adapter = RecordingAdapter()
+
+    summary = PredictionBatch(jobs).run(adapter)
+
+    assert adapter.setup_calls == [("alphafold3", "shared-model-config")]
+    assert adapter.predicted == ["first", "broken", "last"]
+    assert summary.completed_job_ids == ("first", "last")
+    assert [(failure.job_id, failure.message) for failure in summary.failures] == [
+        ("broken", "bad fold")
+    ]
+    assert summary.exit_code == 1
+
+
+def test_batch_continues_after_a_recoverable_job_preparation_failure(tmp_path):
+    from alphapulldown.prediction_batch import PredictionBatch, PredictionJob
+
+    jobs = (
+        PredictionJob("invalid", "missing.json", tmp_path / "invalid"),
+        PredictionJob("valid", "A+B", tmp_path / "valid"),
+    )
+
+    class RecordingAdapter:
+        def __init__(self):
+            self.setup_calls = []
+            self.predicted = []
+
+        def configuration_for(self, job):
+            if job.job_id == "invalid":
+                raise FileNotFoundError(job.input)
+            return "shared-configuration"
+
+        def setup(self, configuration):
+            self.setup_calls.append(configuration)
+            return "resident-session"
+
+        def predict(self, session, job):
+            self.predicted.append(job.job_id)
+
+    adapter = RecordingAdapter()
+
+    summary = PredictionBatch(jobs).run(adapter)
+
+    assert adapter.setup_calls == ["shared-configuration"]
+    assert adapter.predicted == ["valid"]
+    assert summary.completed_job_ids == ("valid",)
+    assert [(failure.job_id, failure.message) for failure in summary.failures] == [
+        ("invalid", "missing.json")
+    ]
+    assert summary.exit_code == 1
+
+
+def test_heterogeneous_batch_is_rejected_before_backend_setup(tmp_path):
+    from alphapulldown.prediction_batch import (
+        PredictionBatch,
+        PredictionBatchError,
+        PredictionJob,
+    )
+
+    jobs = (
+        PredictionJob("monomer", "A", tmp_path / "monomer"),
+        PredictionJob("multimer", "A+B", tmp_path / "multimer"),
+    )
+
+    class MixedConfigurationAdapter:
+        setup_calls = 0
+
+        def configuration_for(self, job):
+            return "multimer" if "+" in job.input else "monomer"
+
+        def setup(self, configuration):
+            self.setup_calls += 1
+
+        def predict(self, session, job):
+            raise AssertionError("prediction must not start")
+
+    adapter = MixedConfigurationAdapter()
+
+    with pytest.raises(PredictionBatchError, match="heterogeneous"):
+        PredictionBatch(jobs).run(adapter)
+
+    assert adapter.setup_calls == 0
+
+
+def test_alphapulldown_adapter_keeps_af3_jobs_independent_with_one_setup(tmp_path):
+    from alphapulldown.prediction_batch import (
+        AlphaPulldownPredictionAdapter,
+        PredictionBatch,
+        PredictionJob,
+    )
+
+    for name in ("first.json", "second.json", "third.json"):
+        (tmp_path / name).write_text(
+            json.dumps({"name": name, "sequences": [], "modelSeeds": [1]}),
+            encoding="utf-8",
+        )
+
+    class RecordingBackend:
+        def __init__(self):
+            self.setup_calls = []
+            self.prediction_jobs = []
+
+        def change_backend(self, backend_name):
+            assert backend_name == "alphafold3"
+
+        def setup(self, **model_flags):
+            self.setup_calls.append(model_flags)
+            return {"model_runner": "resident-runner"}
+
+        def predict(self, **kwargs):
+            objects = kwargs["objects_to_model"]
+            self.prediction_jobs.append(objects)
+            entry = objects[0]
+            yield {
+                "object": entry["object"],
+                "output_dir": entry["output_dir"],
+                "prediction_results": {"ok": True},
+            }
+
+        def postprocess(self, **kwargs):
+            return None
+
+    flags = _prediction_flags(tmp_path, "alphafold3")
+    jobs = (
+        PredictionJob("first", "first.json+second.json", tmp_path / "out-first"),
+        PredictionJob("second", "third.json", tmp_path / "out-second"),
+    )
+    backend = RecordingBackend()
+
+    summary = PredictionBatch(jobs).run(
+        AlphaPulldownPredictionAdapter(flags, backend=backend)
+    )
+
+    assert summary.exit_code == 0
+    assert len(backend.setup_calls) == 1
+    assert [len(job) for job in backend.prediction_jobs] == [2, 1]
+    assert [job[0]["output_dir"] for job in backend.prediction_jobs] == [
+        str(tmp_path / "out-first"),
+        str(tmp_path / "out-second"),
+    ]
+
+
+def test_alphapulldown_adapter_reuses_af2_runners_across_jobs(tmp_path):
+    from alphapulldown.objects import MonomericObject
+    from alphapulldown.prediction_batch import (
+        AlphaPulldownPredictionAdapter,
+        PredictionBatch,
+        PredictionJob,
+    )
+
+    for name in ("A", "B"):
+        with (tmp_path / f"{name}.pkl").open("wb") as handle:
+            pickle.dump(MonomericObject(name, "ACDE"), handle)
+
+    class RecordingBackend:
+        def __init__(self):
+            self.setup_calls = []
+            self.predicted = []
+
+        def change_backend(self, backend_name):
+            assert backend_name == "alphafold2"
+
+        def setup(self, **model_flags):
+            self.setup_calls.append(model_flags)
+            return {"model_runners": {"model": "resident-runner"}}
+
+        def predict(self, **kwargs):
+            entry = kwargs["objects_to_model"][0]
+            self.predicted.append(entry["object"].description)
+            yield {
+                "object": entry["object"],
+                "output_dir": entry["output_dir"],
+                "prediction_results": {"model": {}},
+            }
+
+        def postprocess(self, **kwargs):
+            return None
+
+    backend = RecordingBackend()
+    batch = PredictionBatch(
+        (
+            PredictionJob("A", "A", tmp_path / "out-A"),
+            PredictionJob("B", "B", tmp_path / "out-B"),
+        )
+    )
+
+    summary = batch.run(
+        AlphaPulldownPredictionAdapter(
+            _prediction_flags(tmp_path, "alphafold2"), backend=backend
+        )
+    )
+
+    assert summary.exit_code == 0
+    assert len(backend.setup_calls) == 1
+    assert backend.setup_calls[0]["model_name"] == "monomer_ptm"
+    assert backend.predicted == ["A", "B"]
+
+
+def test_batch_command_is_in_the_installed_script_interface():
+    repository = Path(__file__).resolve().parents[2]
+    command = repository / "alphapulldown/scripts/run_structure_prediction_batch.py"
+
+    assert command.is_file()
+    assert "./alphapulldown/scripts/run_structure_prediction_batch.py" in (
+        repository / "pyproject.toml"
+    ).read_text(encoding="utf-8")

--- a/test/unit/test_prediction_batch.py
+++ b/test/unit/test_prediction_batch.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 import pickle
 from types import SimpleNamespace
@@ -596,3 +597,26 @@ def test_batch_command_is_in_the_installed_script_interface():
     assert "./alphapulldown/scripts/run_structure_prediction_batch.py" in (
         repository / "pyproject.toml"
     ).read_text(encoding="utf-8")
+
+
+def test_metadata_is_taken_from_every_feature_directory(tmp_path):
+    """The old single-fold copy only ever saw the LAST feature directory."""
+    from alphapulldown import fold_preparation
+    from alphapulldown.objects import MonomericObject
+
+    first, second, out = tmp_path / "f1", tmp_path / "f2", tmp_path / "out"
+    for d in (first, second, out):
+        d.mkdir()
+    old = first / "P1_feature_metadata_2024-01-01.json"
+    old.write_text("{}", encoding="utf-8")
+    os.utime(old, (1_000_000, 1_000_000))
+    newer = second / "P1_feature_metadata_2025-01-01.json"
+    newer.write_text('{"newer": true}', encoding="utf-8")
+    os.utime(newer, (2_000_000, 2_000_000))
+
+    interactor = MonomericObject("P1", "MKV")
+    flags = SimpleNamespace(features_directory=[str(first), str(second)])
+    fold_preparation._copy_feature_metadata([interactor], flags, str(out))
+
+    copied = sorted(p.name for p in out.iterdir())
+    assert copied == ["P1_feature_metadata_2025-01-01.json"]

--- a/test/unit/test_prediction_batch.py
+++ b/test/unit/test_prediction_batch.py
@@ -312,6 +312,132 @@ def test_heterogeneous_batch_is_rejected_before_backend_setup(tmp_path):
     assert adapter.setup_calls == 0
 
 
+def test_manifest_command_returns_a_concise_rejection_for_malformed_json(tmp_path):
+    from alphapulldown.prediction_batch import execute_prediction_manifest
+
+    manifest = tmp_path / "jobs.jsonl"
+    manifest.write_text("{not-json}\n", encoding="utf-8")
+
+    outcome = execute_prediction_manifest(manifest, adapter=object())
+
+    assert outcome.exit_code == 2
+    assert outcome.summary_message == (
+        "Prediction batch summary: 0 completed, batch rejected"
+    )
+    assert outcome.rejection == (
+        "Invalid JSON on manifest line 1: "
+        "Expecting property name enclosed in double quotes"
+    )
+
+
+def test_manifest_command_returns_a_concise_rejection_when_file_is_missing(tmp_path):
+    from alphapulldown.prediction_batch import execute_prediction_manifest
+
+    missing_manifest = tmp_path / "missing.jsonl"
+
+    outcome = execute_prediction_manifest(missing_manifest, adapter=object())
+
+    assert outcome.exit_code == 2
+    assert outcome.rejection.startswith("Cannot read prediction batch manifest ")
+    assert str(missing_manifest) in outcome.rejection
+
+
+def test_manifest_command_returns_a_concise_rejection_for_mixed_configurations(
+    tmp_path,
+):
+    from alphapulldown.prediction_batch import execute_prediction_manifest
+
+    manifest = tmp_path / "jobs.jsonl"
+    manifest.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "input": input_value,
+                    "output_directory": output_directory,
+                }
+            )
+            for job_id, input_value, output_directory in (
+                ("monomer", "A", "monomer-output"),
+                ("multimer", "A+B", "multimer-output"),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class MixedConfigurationAdapter:
+        def configuration_for(self, job):
+            return "multimer" if "+" in job.input else "monomer"
+
+        def setup(self, configuration):
+            raise AssertionError("backend setup must not run")
+
+        def predict(self, session, job):
+            raise AssertionError("prediction must not run")
+
+    outcome = execute_prediction_manifest(
+        manifest, adapter=MixedConfigurationAdapter()
+    )
+
+    assert outcome.exit_code == 2
+    assert outcome.summary_message == (
+        "Prediction batch summary: 0 completed, batch rejected"
+    )
+    assert outcome.rejection == (
+        "Prediction batch contains heterogeneous backend/model configurations"
+    )
+
+
+def test_manifest_command_does_not_misreport_backend_setup_errors_as_read_errors(
+    tmp_path,
+):
+    from alphapulldown.prediction_batch import execute_prediction_manifest
+
+    manifest = tmp_path / "jobs.jsonl"
+    manifest.write_text(
+        json.dumps(
+            {
+                "job_id": "fold",
+                "input": "A",
+                "output_directory": "output",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class MissingModelAdapter:
+        def configuration_for(self, job):
+            return "shared-configuration"
+
+        def setup(self, configuration):
+            raise FileNotFoundError("/models/params")
+
+        def predict(self, session, job):
+            raise AssertionError("prediction must not run")
+
+    with pytest.raises(FileNotFoundError, match="/models/params"):
+        execute_prediction_manifest(manifest, adapter=MissingModelAdapter())
+
+
+@pytest.mark.parametrize(
+    "outcome_kwargs",
+    [
+        {},
+        {
+            "summary": SimpleNamespace(exit_code=0),
+            "rejection": "invalid manifest",
+        },
+    ],
+)
+def test_batch_outcome_requires_exactly_one_result(outcome_kwargs):
+    from alphapulldown.prediction_batch import PredictionBatchOutcome
+
+    with pytest.raises(ValueError, match="exactly one"):
+        PredictionBatchOutcome(**outcome_kwargs)
+
+
 def test_alphapulldown_adapter_keeps_af3_jobs_independent_with_one_setup(tmp_path):
     from alphapulldown.prediction_batch import (
         AlphaPulldownPredictionAdapter,
@@ -424,6 +550,42 @@ def test_alphapulldown_adapter_reuses_af2_runners_across_jobs(tmp_path):
     assert len(backend.setup_calls) == 1
     assert backend.setup_calls[0]["model_name"] == "monomer_ptm"
     assert backend.predicted == ["A", "B"]
+
+
+@pytest.mark.parametrize(
+    ("backend_name", "fold_specification", "expected_model_name"),
+    [
+        ("alphafold2", "A", "monomer_ptm"),
+        ("alphafold2", "A+B", "multimer"),
+        ("alphafold2", "A:2", "multimer"),
+        ("alphafold2", "A:1-3", "monomer_ptm"),
+        ("alphafold3", "fold.json", "monomer_ptm"),
+    ],
+)
+def test_adapter_configuration_matches_the_shared_parser_contract(
+    tmp_path, backend_name, fold_specification, expected_model_name
+):
+    from alphapulldown.prediction_batch import (
+        AlphaPulldownPredictionAdapter,
+        PredictionJob,
+    )
+
+    for name in ("A", "B"):
+        (tmp_path / f"{name}.pkl").touch()
+    (tmp_path / "fold.json").write_text(
+        json.dumps({"name": "fold", "sequences": [], "modelSeeds": [1]}),
+        encoding="utf-8",
+    )
+    adapter = AlphaPulldownPredictionAdapter(
+        _prediction_flags(tmp_path, backend_name), backend=object()
+    )
+    job = PredictionJob(
+        "contract-case", fold_specification, tmp_path / "prediction"
+    )
+
+    configuration = adapter.configuration_for(job)
+
+    assert configuration["model_name"] == expected_model_name
 
 
 def test_batch_command_is_in_the_installed_script_interface():

--- a/test/unit/test_prediction_batch_cli.py
+++ b/test/unit/test_prediction_batch_cli.py
@@ -1,0 +1,70 @@
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "alphapulldown/scripts/run_structure_prediction_batch.py"
+)
+
+
+def _load_batch_command(monkeypatch):
+    from alphapulldown import scripts
+
+    prediction_command = ModuleType(
+        "alphapulldown.scripts.run_structure_prediction"
+    )
+    prediction_command.backend = object()
+    prediction_command._validate_flags_for_backend = lambda _backend: None
+    monkeypatch.setitem(
+        sys.modules,
+        "alphapulldown.scripts.run_structure_prediction",
+        prediction_command,
+    )
+    monkeypatch.setattr(
+        scripts, "run_structure_prediction", prediction_command, raising=False
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "test_prediction_batch_command", SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_reports_rejected_manifest_and_exits_without_a_traceback(
+    monkeypatch, tmp_path
+):
+    command = _load_batch_command(monkeypatch)
+    manifest = tmp_path / "invalid.jsonl"
+    manifest.write_text("{invalid}\n", encoding="utf-8")
+    command.FLAGS = SimpleNamespace(
+        fold_backend="alphafold2", manifest=str(manifest)
+    )
+    messages = []
+    monkeypatch.setattr(
+        command.logging,
+        "error",
+        lambda template, *args: messages.append(template % args),
+    )
+    monkeypatch.setattr(
+        command.logging,
+        "info",
+        lambda template, *args: messages.append(template % args),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        command.main([])
+
+    assert exit_info.value.code == 2
+    assert messages == [
+        "Prediction batch rejected: Invalid JSON on manifest line 1: "
+        "Expecting property name enclosed in double quotes",
+        "Prediction batch summary: 0 completed, batch rejected",
+    ]

--- a/test/unit/test_resident_container_contract.py
+++ b/test/unit/test_resident_container_contract.py
@@ -11,7 +11,7 @@ def test_af2_image_installs_the_checked_out_source_and_smokes_batch_command():
 
     assert "COPY . /AlphaPulldown" in dockerfile
     assert "git clone --recurse-submodules https://github.com/KosinskiLab/AlphaPulldown" not in dockerfile
-    assert "run_structure_prediction_batch.py --helpshort" in dockerfile
+    assert "command -v run_structure_prediction_batch.py" in dockerfile
 
 
 def test_pull_requests_build_af2_without_registry_or_ssh_credentials():

--- a/test/unit/test_resident_container_contract.py
+++ b/test/unit/test_resident_container_contract.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+
+
+def test_af2_image_installs_the_checked_out_source_and_smokes_batch_command():
+    dockerfile = (REPOSITORY / "docker/alphafold2.dockerfile").read_text(
+        encoding="utf-8"
+    )
+
+    assert "COPY . /AlphaPulldown" in dockerfile
+    assert "git clone --recurse-submodules https://github.com/KosinskiLab/AlphaPulldown" not in dockerfile
+    assert "run_structure_prediction_batch.py --helpshort" in dockerfile
+
+
+def test_pull_requests_build_af2_without_registry_or_ssh_credentials():
+    workflow = (REPOSITORY / ".github/workflows/github_actions.yml").read_text(
+        encoding="utf-8"
+    )
+    af2_job = workflow.split("  build-alphafold2-container:", 1)[1].split(
+        "  # build-alphalink-container:", 1
+    )[0]
+
+    assert "submodules: recursive" in af2_job
+    assert "if: github.event_name != 'pull_request'" in af2_job
+    assert "if: github.event_name == 'pull_request'" in af2_job
+    assert "push: false" in af2_job

--- a/test/unit/test_script_entrypoints.py
+++ b/test/unit/test_script_entrypoints.py
@@ -93,6 +93,7 @@ class _FakeFlagsModule(types.ModuleType):
     def __init__(self):
         super().__init__("absl.flags")
         self.FLAGS = _FakeFlags()
+        self.required_flags = set()
 
     def DEFINE_string(self, name, default, *_args, **_kwargs):
         return self.FLAGS.define(name, default)
@@ -117,11 +118,11 @@ class _FakeFlagsModule(types.ModuleType):
     def DEFINE_enum_class(self, name, default, *_args, **_kwargs):
         return self.FLAGS.define(name, default)
 
-    def mark_flag_as_required(self, *_args, **_kwargs):
-        return None
+    def mark_flag_as_required(self, name, *_args, **_kwargs):
+        self.required_flags.add(name)
 
-    def mark_flags_as_required(self, *_args, **_kwargs):
-        return None
+    def mark_flags_as_required(self, names, *_args, **_kwargs):
+        self.required_flags.update(names)
 
 
 def _restore_modules(saved_modules: dict[str, types.ModuleType | None]) -> None:
@@ -174,7 +175,10 @@ def _load_run_structure_prediction_module():
     absl_pkg.logging = logging_mod
 
     jax_mod = types.ModuleType("jax")
-    jax_mod.local_devices = lambda backend="gpu": []
+    def _unexpected_jax_initialization(*_args, **_kwargs):
+        raise AssertionError("importing prediction flags must not initialize JAX")
+
+    jax_mod.local_devices = _unexpected_jax_initialization
 
     class ModelsToRelax(Enum):
         NONE = "none"
@@ -436,6 +440,12 @@ def test_validate_flags_for_backend_rejects_disallowed_flags(run_structure_predi
 
     with pytest.raises(ValueError, match="num_cycle"):
         run_structure_prediction_module._validate_flags_for_backend("alphafold3")
+
+
+def test_importing_shared_prediction_flags_does_not_require_single_job_outputs(
+    run_structure_prediction_module,
+):
+    assert run_structure_prediction_module.flags.required_flags == set()
 
 
 def test_validate_flags_for_af3_allows_modelcif_conversion(

--- a/test/unit/test_script_entrypoints.py
+++ b/test/unit/test_script_entrypoints.py
@@ -182,6 +182,7 @@ def _load_run_structure_prediction_module():
         BEST = "best"
 
     root_pkg = _package("alphapulldown")
+    root_pkg.__path__ = [str(RUN_STRUCTURE_PREDICTION_PATH.parents[1])]
     folding_backend_mod = types.ModuleType("alphapulldown.folding_backend")
     folding_backend_mod.backend = SimpleNamespace()
     af2_backend_mod = types.ModuleType(

--- a/test/unit/test_script_entrypoints.py
+++ b/test/unit/test_script_entrypoints.py
@@ -175,10 +175,7 @@ def _load_run_structure_prediction_module():
     absl_pkg.logging = logging_mod
 
     jax_mod = types.ModuleType("jax")
-    def _unexpected_jax_initialization(*_args, **_kwargs):
-        raise AssertionError("importing prediction flags must not initialize JAX")
-
-    jax_mod.local_devices = _unexpected_jax_initialization
+    jax_mod.local_devices = lambda backend="gpu": []
 
     class ModelsToRelax(Enum):
         NONE = "none"
@@ -446,6 +443,14 @@ def test_importing_shared_prediction_flags_does_not_require_single_job_outputs(
     run_structure_prediction_module,
 ):
     assert run_structure_prediction_module.flags.required_flags == set()
+
+
+def test_single_prediction_initializes_jax_before_importing_backend():
+    source = RUN_STRUCTURE_PREDICTION_PATH.read_text(encoding="utf-8")
+
+    assert source.index("gpus = jax.local_devices(backend='gpu')") < source.index(
+        "from alphapulldown.folding_backend import backend"
+    )
 
 
 def test_validate_flags_for_af3_allows_modelcif_conversion(

--- a/test/unit/test_script_entrypoints.py
+++ b/test/unit/test_script_entrypoints.py
@@ -152,6 +152,9 @@ def _load_run_structure_prediction_module():
         "alphapulldown.folding_backend",
         "alphapulldown.folding_backend.alphafold2_backend",
         "alphapulldown.objects",
+        # fold_preparation binds the object classes at import time, so it has to be
+        # evicted too or a cached copy keeps the real ones.
+        "alphapulldown.fold_preparation",
         "alphapulldown.utils",
         "alphapulldown.utils.modelling_setup",
         "alphapulldown.utils.output_paths",
@@ -263,6 +266,9 @@ def _load_run_structure_prediction_module():
     }
     for name, module in modules.items():
         sys.modules[name] = module
+    # fold_preparation binds the object classes at import time. If another test file
+    # already imported it against the real ones, drop it so it re-imports against these.
+    sys.modules.pop("alphapulldown.fold_preparation", None)
 
     root_pkg.folding_backend = folding_backend_mod
     root_pkg.objects = objects_mod
@@ -778,21 +784,23 @@ def test_pre_modelling_setup_warns_for_long_paths_and_uses_chopped_metadata_name
     )
     _set_flag(run_structure_prediction_module.FLAGS, "use_ap_style", False)
 
+    import alphapulldown.fold_preparation as fold_preparation
+
     warnings = []
     glob_patterns = []
     created_dirs = []
     monkeypatch.setattr(
-        run_structure_prediction_module.glob,
+        fold_preparation.glob,
         "glob",
         lambda pattern: glob_patterns.append(pattern) or [],
     )
     monkeypatch.setattr(
-        run_structure_prediction_module.logging,
+        fold_preparation.logging,
         "warning",
-        lambda message: warnings.append(message),
+        lambda message, *args: warnings.append(message % args if args else message),
     )
     monkeypatch.setattr(
-        run_structure_prediction_module.os,
+        fold_preparation.os,
         "makedirs",
         lambda path, exist_ok=True: created_dirs.append(path),
     )
@@ -813,7 +821,7 @@ def test_pre_modelling_setup_warns_for_long_paths_and_uses_chopped_metadata_name
     assert glob_patterns == ["/features/protA_feature_metadata_*.json*"]
     assert created_dirs == [long_output_dir]
     assert any("Output directory path is too long" in message for message in warnings)
-    assert any("No feature metadata found for fragmentA" in message for message in warnings)
+    assert any("No feature metadata found for protA" in message for message in warnings)
 
 
 def test_pre_modelling_setup_allows_skip_msa_monomers_with_default_pair_flag(

--- a/workflows/resident-inference.md
+++ b/workflows/resident-inference.md
@@ -40,10 +40,16 @@ Each line is one JSON object:
 1. Validate the complete manifest.
 2. Select one backend adapter and initialize its runners exactly once.
 3. Parse and execute jobs in manifest order, one at a time.
-4. Release the completed job before preparing the next one.
-5. Record ordinary per-job exceptions and continue; setup failures and process
-   interrupts remain fatal.
-6. Print one final summary. Exit nonzero after the summary if any job failed.
+4. Drop references to completed job-local inputs before preparing the next one.
+   Model runners and JAX/XLA allocator state remain resident; this does not imply
+   that host or device memory is returned to the operating system.
+5. Record ordinary Python per-job exceptions and continue. Setup failures and
+   process interrupts remain fatal. Native CUDA/XLA aborts, process termination,
+   or a backend left unusable after an error cannot be isolated: they may stop the
+   batch or cause its remaining jobs to fail.
+6. Print one final summary for completed execution and rejected manifests. Native
+   process termination cannot produce a Python-level summary. Exit nonzero after
+   the summary if any job failed or the manifest was rejected.
 
 The existing command preserves its current `--input` and `--output_directory`
 semantics while delegating runner lifecycle and execution to the same module.

--- a/workflows/resident-inference.md
+++ b/workflows/resident-inference.md
@@ -1,0 +1,69 @@
+# Resident inference workflow
+
+## Trigger
+
+Run `run_structure_prediction_batch.py --manifest <jobs.jsonl>` when several
+independent folds share one backend and model configuration. The existing
+`run_structure_prediction.py` command remains the entry point for its current
+single-invocation semantics.
+
+## Public seam
+
+`PredictionBatch` is the shared interface used by both commands. A
+`PredictionJob` contains only `job_id`, `input`, and `output_directory`.
+`PredictionBatch.from_jsonl(path)` loads one job per non-empty line; relative
+filesystem paths are resolved from the manifest's parent directory.
+
+The execution interface accepts the AlphaPulldown prediction adapter and returns
+a summary containing completed job IDs and failures. The adapter owns backend
+specific parsing and prediction; the batch owns validation, one-time setup,
+job isolation, and the final status.
+
+## Manifest contract
+
+Each line is one JSON object:
+
+```json
+{"job_id":"A_and_B","input":"A+B","output_directory":"predictions/A_and_B"}
+```
+
+- All three fields are required non-empty strings; unknown fields are rejected.
+- `job_id` and resolved `output_directory` must each be unique.
+- Jobs are independent. Delimited chains inside one `input` still compose one
+  fold according to the unchanged `alphapulldown-input-parser` behavior.
+- Every job uses the same backend and model configuration. A heterogeneous batch
+  is rejected rather than silently changing runners.
+- Manifest validation completes before model setup starts.
+
+## Run behavior
+
+1. Validate the complete manifest.
+2. Select one backend adapter and initialize its runners exactly once.
+3. Parse and execute jobs in manifest order, one at a time.
+4. Release the completed job before preparing the next one.
+5. Record ordinary per-job exceptions and continue; setup failures and process
+   interrupts remain fatal.
+6. Print one final summary. Exit nonzero after the summary if any job failed.
+
+The existing command preserves its current `--input` and `--output_directory`
+semantics while delegating runner lifecycle and execution to the same module.
+
+## Acceptance criteria
+
+- A two-job AF2 or AF3 batch calls backend setup once and predicts both folds
+  independently into their requested directories.
+- A failure in the first job does not prevent the second job from running, and
+  the final status is nonzero with the failed `job_id` in the summary.
+- Duplicate IDs or output directories fail before backend setup.
+- Relative output directories resolve against the manifest directory.
+- Multiple chains in one job remain one complex; two manifest lines never merge.
+- Existing command behavior and focused AF2/AF3 tests remain green.
+- No GPU is needed for interface tests; only the heavy backend adapter is faked.
+
+## Workflow integration
+
+AlphaPulldownSnakemake writes one JSONL manifest for each existing size-binned
+batch. `batch_size > 1` invokes the batch command once inside one Slurm
+allocation; `batch_size <= 1` keeps the existing command for compatibility with
+older containers. Existing token sorting, token caps, largest-fold memory sizing,
+count-scaled runtime, retry behavior, and the batch sentinel are unchanged.


### PR DESCRIPTION
## Summary

- add a reusable resident inference batch module for AF2 and AF3
- load each model once and process JSONL-described jobs sequentially
- isolate per-job failures while preserving successful outputs
- keep the existing single-job command on the same implementation path

## Tests

- focused resident tests: 91 passed
- unit suite: 404 passed, 4 skipped
- GitHub CI: smoke tests, coverage, AF2 image, and AF3 image passed

Companion workflow PR: KosinskiLab/AlphaPulldownSnakemake#53.

Related MMseqs2-GPU core PR: #637.