### PR TITLE
feat: add batched local MMseqs2-GPU features

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -159,15 +159,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: webfactory/ssh-agent@v0.9.0
+        if: github.event_name != 'pull_request'
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: actions/checkout@v4
       - run: rm -rf /opt/hostedtoolcache
       - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/setup-buildx-action@v3
+      - name: Build alphafold2 container
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/alphafold2.dockerfile
+          push: false
       - name: Build and push alphafold2 container
         if: github.event_name == 'push'
         uses: docker/build-push-action@v5

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,5 +4,5 @@
 - **Feature batch**: an ordered collection of feature requests handled as one operation.
 - **Database identifier**: the caller-supplied immutable identity of one MMseqs2 database build; cache validity depends on it, not only its filesystem path.
 - **Feature artifact**: the standard AlphaFold 3 JSON (optionally LZMA-compressed) produced for one feature request.
-- **Cache hit**: an existing feature artifact whose sequence, MMseqs2 settings, and database identifiers match the request.
+- **Cache hit**: an existing feature artifact whose sequence, MMseqs2 executable version, settings, and database identifiers match the request.
 - **Recoverable failure**: a failure isolated to one sequence; remaining requests continue and the batch reports a nonzero summary after writing successful artifacts.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,3 +10,7 @@
 - **MSA cache hit**: an existing MSA bundle whose sequence, MMseqs2 executable version, search settings, and database identifiers match the request.
 - **Feature cache hit**: an existing feature artifact whose MSA provenance, maximum template date, PDB seqres identity, and mmCIF identity match the request.
 - **Recoverable failure**: a failure isolated to one sequence; remaining requests continue and the batch reports a nonzero summary after writing successful artifacts.
+- **Database role**: whether a configured MMseqs2 database supplies unpaired hits
+  (uniref90, mgnify, small_bfd, merged into one MSA) or paired hits (uniprot, whose
+  UniProt taxon headers let AlphaFold 3 pair chains by species). Roles are named, not
+  inferred from a position in the configured list.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,7 +2,11 @@
 
 - **Feature request**: one named protein sequence requiring an AlphaFold 3 feature artifact.
 - **Feature batch**: an ordered collection of feature requests handled as one operation.
+- **MSA batch**: the GPU stage that searches MMseqs2 and durably publishes one reusable MSA bundle per feature request.
+- **Feature finalization**: the CPU stage that reads an MSA bundle, performs native AF3 template search, and publishes the standard AF3 feature artifact.
+- **MSA bundle**: an atomic intermediate JSON containing one sequence, merged unpaired A3M, paired A3M, and complete MMseqs/database provenance.
 - **Database identifier**: the caller-supplied immutable identity of one MMseqs2 database build; cache validity depends on it, not only its filesystem path.
 - **Feature artifact**: the standard AlphaFold 3 JSON (optionally LZMA-compressed) produced for one feature request.
-- **Cache hit**: an existing feature artifact whose sequence, MMseqs2 executable version, settings, and database identifiers match the request.
+- **MSA cache hit**: an existing MSA bundle whose sequence, MMseqs2 executable version, search settings, and database identifiers match the request.
+- **Feature cache hit**: an existing feature artifact whose MSA provenance, maximum template date, PDB seqres identity, and mmCIF identity match the request.
 - **Recoverable failure**: a failure isolated to one sequence; remaining requests continue and the batch reports a nonzero summary after writing successful artifacts.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,8 @@
+# Domain language
+
+- **Feature request**: one named protein sequence requiring an AlphaFold 3 feature artifact.
+- **Feature batch**: an ordered collection of feature requests handled as one operation.
+- **Database identifier**: the caller-supplied immutable identity of one MMseqs2 database build; cache validity depends on it, not only its filesystem path.
+- **Feature artifact**: the standard AlphaFold 3 JSON (optionally LZMA-compressed) produced for one feature request.
+- **Cache hit**: an existing feature artifact whose sequence, MMseqs2 settings, and database identifiers match the request.
+- **Recoverable failure**: a failure isolated to one sequence; remaining requests continue and the batch reports a nonzero summary after writing successful artifacts.

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -23,6 +23,22 @@ from alphapulldown.utils.feature_metadata import (
 
 _PROTEIN_RESIDUES = frozenset("ACDEFGHIKLMNPQRSTVWYX")
 
+# The two database roles. Unpaired hits are merged into one MSA; paired hits keep their
+# UniProt taxon headers so AlphaFold 3 can pair chains by species. Getting these the
+# wrong way round produces a plausible-looking MSA and silently wrong pairing, so the
+# roles are named here rather than recovered from a position in a tuple.
+UNPAIRED_DATABASE_NAMES = ("uniref90", "mgnify", "small_bfd")
+PAIRED_DATABASE_NAME = "uniprot"
+DATABASE_NAMES = (*UNPAIRED_DATABASE_NAMES, PAIRED_DATABASE_NAME)
+
+DEFAULT_MAX_SEQUENCES = {
+    "uniref90": 10_000,
+    "mgnify": 5_000,
+    "small_bfd": 5_000,
+    "uniprot": 50_000,
+}
+_FALLBACK_MAX_SEQUENCES = 5_000
+
 
 def _validate_feature_requests(requests: Sequence[FeatureRequest]) -> None:
     names = [request.name for request in requests]
@@ -72,6 +88,14 @@ class DatabaseSpec:
     path: Path
     identifier: str
     max_sequences: int | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DatabaseSelection:
+    """The configured databases with their roles named."""
+
+    unpaired: tuple[DatabaseSpec, ...]
+    paired: DatabaseSpec
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -327,12 +351,7 @@ class SubprocessMmseqsProcess:
 
 
 def _default_max_sequences(database_name: str) -> int:
-    return {
-        "uniref90": 10_000,
-        "mgnify": 5_000,
-        "small_bfd": 5_000,
-        "uniprot": 50_000,
-    }.get(database_name, 5_000)
+    return DEFAULT_MAX_SEQUENCES.get(database_name, _FALLBACK_MAX_SEQUENCES)
 
 
 class MsaBatch:
@@ -510,13 +529,15 @@ class MsaBatch:
         unpaired_names = tuple(
             database.name for database in self._settings.unpaired_databases
         )
-        if unpaired_names != ("uniref90", "mgnify", "small_bfd"):
+        if unpaired_names != UNPAIRED_DATABASE_NAMES:
             raise ValueError(
-                "unpaired_databases must explicitly provide uniref90, mgnify, "
-                "and small_bfd in that order"
+                "unpaired_databases must explicitly provide "
+                f"{', '.join(UNPAIRED_DATABASE_NAMES)} in that order"
             )
-        if self._settings.paired_database.name != "uniprot":
-            raise ValueError("paired_database must explicitly provide uniprot")
+        if self._settings.paired_database.name != PAIRED_DATABASE_NAME:
+            raise ValueError(
+                f"paired_database must explicitly provide {PAIRED_DATABASE_NAME}"
+            )
         for database in (
             *self._settings.unpaired_databases,
             self._settings.paired_database,

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -21,12 +21,44 @@ from alphapulldown.utils.feature_metadata import (
 _PROTEIN_RESIDUES = frozenset("ACDEFGHIKLMNPQRSTVWYX")
 
 
+def _validate_feature_requests(requests: Sequence[FeatureRequest]) -> None:
+    names = [request.name for request in requests]
+    if len(set(names)) != len(names):
+        raise ValueError("Feature request names must be unique")
+    for request in requests:
+        if not request.name or Path(request.name).name != request.name:
+            raise ValueError(f"Invalid feature request name: {request.name!r}")
+        sequence = request.sequence.upper()
+        if not sequence or set(sequence) - _PROTEIN_RESIDUES:
+            raise ValueError(
+                f"Feature request {request.name!r} is not a protein sequence"
+            )
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class FeatureRequest:
     """One named protein sequence requiring an AF3 feature artifact."""
 
     name: str
     sequence: str
+
+
+def protein_requests_from_fastas(
+    fasta_paths: Sequence[str | Path],
+) -> tuple[FeatureRequest, ...]:
+    """Read protein requests without importing AlphaFold or JAX."""
+    from alphapulldown.utils.file_handling import iter_seqs
+    from alphapulldown.utils.sequence_types import get_af3_chain_kind
+
+    requests = []
+    for sequence, description in iter_seqs([str(path) for path in fasta_paths]):
+        if get_af3_chain_kind(description, sequence) != "protein":
+            raise ValueError(
+                "Batched local MMseqs2-GPU features accept proteins only; "
+                f"{description!r} is not a protein"
+            )
+        requests.append(FeatureRequest(name=description, sequence=sequence))
+    return tuple(requests)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -40,8 +72,8 @@ class DatabaseSpec:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
-class FeatureBatchSettings:
-    """Settings that determine batching, search results, and persistence."""
+class MsaBatchSettings:
+    """GPU MSA-stage settings; no AlphaFold/JAX configuration belongs here."""
 
     output_dir: Path
     temp_dir: Path
@@ -50,10 +82,40 @@ class FeatureBatchSettings:
     max_sequences_per_batch: int
     max_residues_per_batch: int
     threads: int
-    sensitivity: float = 7.5
+    e_value: float = 1e-4
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FeatureFinalizationSettings:
+    """CPU AF3 finalization settings and complete template provenance."""
+
+    output_dir: Path
+    msa_input_dir: Path
+    max_template_date: str
+    template_seqres_database_id: str
+    template_mmcif_database_id: str
+    compress: bool = False
+    base_metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FeatureBatchSettings:
+    """Compatibility settings for the composed all-stage interface."""
+
+    output_dir: Path
+    temp_dir: Path
+    unpaired_databases: tuple[DatabaseSpec, ...]
+    paired_database: DatabaseSpec
+    max_sequences_per_batch: int
+    max_residues_per_batch: int
+    threads: int
+    msa_output_dir: Path | None = None
     e_value: float = 1e-4
     compress: bool = False
     base_metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+    max_template_date: str = ""
+    template_seqres_database_id: str = ""
+    template_mmcif_database_id: str = ""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -75,10 +137,27 @@ class FeatureBatchResult:
     failures: tuple[FeatureFailure, ...]
 
 
+def write_batch_summary(path: Path, result: FeatureBatchResult) -> None:
+    """Atomically publish a completion record for an entirely successful stage."""
+    if result.failures:
+        raise ValueError("A completion summary cannot represent a failed batch")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_atomic(
+        path,
+        {
+            "schemaVersion": 1,
+            "written": [artifact.name for artifact in result.written],
+            "reused": [artifact.name for artifact in result.reused],
+        },
+    )
+
+
 class MmseqsProcess(Protocol):
     """Process operations performed by the external MMseqs2 executable."""
 
     def identity(self) -> str: ...
+
+    def search_mode(self) -> str: ...
 
     def create_query_database(self, query_fasta: Path, query_db: Path) -> None: ...
 
@@ -88,7 +167,7 @@ class MmseqsProcess(Protocol):
         database: DatabaseSpec,
         result_db: Path,
         work_dir: Path,
-        settings: FeatureBatchSettings,
+        settings: MsaBatchSettings | FeatureBatchSettings,
     ) -> None: ...
 
     def result_to_msa(
@@ -105,8 +184,9 @@ class MmseqsProcess(Protocol):
 class SubprocessMmseqsProcess:
     """Production adapter for one local MMseqs2 executable."""
 
-    def __init__(self, binary_path: str | Path):
+    def __init__(self, binary_path: str | Path, *, gpu: bool = True):
         self._binary_path = str(binary_path)
+        self._gpu = gpu
 
     def _run(self, command: Sequence[str]) -> str:
         try:
@@ -131,6 +211,9 @@ class SubprocessMmseqsProcess:
             raise RuntimeError("MMseqs2 version command returned no identity")
         return version
 
+    def search_mode(self) -> str:
+        return "gpu" if self._gpu else "cpu-contract"
+
     def create_query_database(self, query_fasta: Path, query_db: Path) -> None:
         self._run(("createdb", str(query_fasta), str(query_db)))
 
@@ -140,7 +223,7 @@ class SubprocessMmseqsProcess:
         database: DatabaseSpec,
         result_db: Path,
         work_dir: Path,
-        settings: FeatureBatchSettings,
+        settings: MsaBatchSettings | FeatureBatchSettings,
     ) -> None:
         max_sequences = database.max_sequences or _default_max_sequences(database.name)
         self._run(
@@ -151,8 +234,6 @@ class SubprocessMmseqsProcess:
                 str(result_db),
                 str(work_dir),
                 "-a",
-                "-s",
-                str(settings.sensitivity),
                 "-e",
                 str(settings.e_value),
                 "--threads",
@@ -160,7 +241,7 @@ class SubprocessMmseqsProcess:
                 "--max-seqs",
                 str(max_sequences),
                 "--gpu",
-                "1",
+                "1" if self._gpu else "0",
             )
         )
 
@@ -207,46 +288,59 @@ def _default_max_sequences(database_name: str) -> int:
     }.get(database_name, 5_000)
 
 
-class FeatureBatch:
-    """Generate many independent AF3 protein artifacts behind one interface."""
+class MsaBatch:
+    """Search and persist reusable per-protein MMseqs2 MSA bundles."""
 
     def __init__(
         self,
         *,
-        settings: FeatureBatchSettings,
+        settings: MsaBatchSettings | FeatureBatchSettings,
         mmseqs_process: MmseqsProcess,
-        af3_pipeline: Any,
     ):
         self._settings = settings
         self._mmseqs = mmseqs_process
-        self._af3_pipeline = af3_pipeline
         self._mmseqs_identity: str | None = None
 
     def generate(self, requests: Sequence[FeatureRequest]) -> FeatureBatchResult:
         requests = tuple(requests)
         self._validate(requests)
-        self._settings.output_dir.mkdir(parents=True, exist_ok=True)
+        self._msa_output_dir.mkdir(parents=True, exist_ok=True)
         self._settings.temp_dir.mkdir(parents=True, exist_ok=True)
 
         reused = []
         missing_requests = []
         msa_by_sequence: dict[str, tuple[str, str]] = {}
         for request in requests:
-            cached = self._read_matching_artifact(request)
+            cached = self._read_matching_msa(request)
             if cached is None:
                 missing_requests.append(request)
                 continue
             path, payload = cached
             reused.append(FeatureArtifact(name=request.name, path=path))
-            protein = payload["sequences"][0]["protein"]
             msa_by_sequence.setdefault(
                 request.sequence,
-                (protein["unpairedMsa"], protein["pairedMsa"]),
+                (payload["unpairedMsa"], payload["pairedMsa"]),
             )
 
         sequence_to_requests: dict[str, list[FeatureRequest]] = {}
         for request in missing_requests:
             sequence_to_requests.setdefault(request.sequence, []).append(request)
+
+        written = []
+        failures = []
+        # A cached sequence can satisfy another name without a new search.
+        for sequence, matching_requests in sequence_to_requests.items():
+            cached_msas = msa_by_sequence.get(sequence)
+            if cached_msas is None:
+                continue
+            for request in matching_requests:
+                try:
+                    payload = self._msa_payload(request, *cached_msas)
+                    path = self._msa_path(request.name)
+                    _write_atomic(path, payload)
+                    written.append(FeatureArtifact(name=request.name, path=path))
+                except Exception as exc:
+                    failures.append(FeatureFailure(name=request.name, error=str(exc)))
 
         sequences_to_search = tuple(
             sequence
@@ -254,83 +348,81 @@ class FeatureBatch:
             if sequence not in msa_by_sequence
         )
         search_errors: dict[str, str] = {}
-        for chunk in self._pack(sequences_to_search):
+        if sequences_to_search:
             try:
-                msa_by_sequence.update(self._search_chunk(chunk))
+                self._process_identity()
+            except Exception as exc:
+                search_errors.update(
+                    (sequence, str(exc)) for sequence in sequences_to_search
+                )
+        for chunk in self._pack(sequences_to_search):
+            if any(sequence in search_errors for sequence in chunk):
+                continue
+            try:
+                chunk_msas = self._search_chunk(chunk)
             except Exception as exc:
                 for sequence in chunk:
                     search_errors[sequence] = str(exc)
-
-        written = []
-        failures = []
-        for request in missing_requests:
-            if request.sequence in search_errors:
-                failures.append(
-                    FeatureFailure(
-                        name=request.name, error=search_errors[request.sequence]
-                    )
-                )
                 continue
-            try:
-                unpaired_msa, paired_msa = msa_by_sequence[request.sequence]
-                payload = self._process_with_af3(request, unpaired_msa, paired_msa)
-                path = self._artifact_path(request.name)
-                self._write_atomic(path, payload)
-                written.append(FeatureArtifact(name=request.name, path=path))
-            except Exception as exc:  # one bad sequence must not hide other outputs
-                failures.append(FeatureFailure(name=request.name, error=str(exc)))
+            # Publish each completed chunk before starting the next expensive search.
+            for sequence, msas in chunk_msas.items():
+                for request in sequence_to_requests[sequence]:
+                    try:
+                        payload = self._msa_payload(request, *msas)
+                        path = self._msa_path(request.name)
+                        _write_atomic(path, payload)
+                        written.append(FeatureArtifact(name=request.name, path=path))
+                    except Exception as exc:
+                        failures.append(
+                            FeatureFailure(name=request.name, error=str(exc))
+                        )
+
+        for sequence, error in search_errors.items():
+            failures.extend(
+                FeatureFailure(name=request.name, error=error)
+                for request in sequence_to_requests[sequence]
+            )
 
         return FeatureBatchResult(
             written=tuple(written), reused=tuple(reused), failures=tuple(failures)
         )
 
-    def _read_matching_artifact(
+    def _read_matching_msa(
         self, request: FeatureRequest
     ) -> tuple[Path, dict[str, Any]] | None:
-        path = self._artifact_path(request.name)
+        path = self._msa_path(request.name)
         if not path.exists():
             return None
         try:
-            opener = lzma.open if path.suffix == ".xz" else open
-            with opener(path, "rt", encoding="utf-8") as handle:
+            with open(path, "rt", encoding="utf-8") as handle:
                 payload = json.load(handle)
-            protein = payload["sequences"][0]["protein"]
-            metadata = extract_metadata_from_af3_json(payload)
-            if protein.get("sequence") != request.sequence or not metadata:
+            if payload.get("sequence") != request.sequence:
                 return None
-            if (
-                metadata[0].get("other", {}).get("mmseqs2_gpu")
-                != self._cache_signature()
-            ):
+            if payload.get("provenance") != self._cache_signature():
                 return None
-            if not isinstance(protein.get("unpairedMsa"), str) or not isinstance(
-                protein.get("pairedMsa"), str
+            if not isinstance(payload.get("unpairedMsa"), str) or not isinstance(
+                payload.get("pairedMsa"), str
             ):
                 return None
             return path, payload
-        except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+        except (
+            KeyError,
+            OSError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+            json.JSONDecodeError,
+        ):
             return None
 
     def _validate(self, requests: Sequence[FeatureRequest]) -> None:
-        names = [request.name for request in requests]
-        if len(set(names)) != len(names):
-            raise ValueError("Feature request names must be unique")
-        for request in requests:
-            if not request.name or Path(request.name).name != request.name:
-                raise ValueError(f"Invalid feature request name: {request.name!r}")
-            sequence = request.sequence.upper()
-            if not sequence or set(sequence) - _PROTEIN_RESIDUES:
-                raise ValueError(
-                    f"Feature request {request.name!r} is not a protein sequence"
-                )
+        _validate_feature_requests(requests)
         if self._settings.max_sequences_per_batch < 1:
             raise ValueError("max_sequences_per_batch must be at least 1")
         if self._settings.max_residues_per_batch < 1:
             raise ValueError("max_residues_per_batch must be at least 1")
         if self._settings.threads < 1:
             raise ValueError("threads must be at least 1")
-        if self._settings.sensitivity <= 0:
-            raise ValueError("sensitivity must be greater than 0")
         if self._settings.e_value <= 0:
             raise ValueError("e_value must be greater than 0")
         unpaired_names = tuple(
@@ -386,8 +478,7 @@ class FeatureBatch:
             root = Path(temporary_directory)
             query_fasta = root / "queries.fasta"
             query_ids = {
-                f"query_{index}": sequence
-                for index, sequence in enumerate(sequences)
+                f"query_{index}": sequence for index, sequence in enumerate(sequences)
             }
             query_fasta.write_text(
                 "".join(
@@ -465,18 +556,183 @@ class FeatureBatch:
             )
             result_path = next((path for path in candidates if path.exists()), None)
             if result_path is None:
-                results[query_id] = f">query\n{query_ids[query_id]}\n"
-            else:
-                results[query_id] = _aligned_fasta_to_a3m(
-                    result_path.read_text(encoding="utf-8"),
-                    query_ids[query_id],
+                raise RuntimeError(
+                    "MMseqs2 unpackdb did not produce an alignment for "
+                    f"{query_id!r} in {output_dir.parent.name!r}"
                 )
-        for query_id, sequence in query_ids.items():
-            results.setdefault(query_id, f">query\n{sequence}\n")
+            results[query_id] = _aligned_fasta_to_a3m(
+                result_path.read_text(encoding="utf-8"),
+                query_ids[query_id],
+            )
+        missing_queries = set(query_ids) - set(results)
+        if missing_queries:
+            raise RuntimeError(
+                "MMseqs2 lookup/unpack output omitted queries: "
+                + ", ".join(sorted(missing_queries))
+            )
         return results
 
-    def _process_with_af3(
+    def _msa_payload(
         self, request: FeatureRequest, unpaired_msa: str, paired_msa: str
+    ) -> dict[str, Any]:
+        return {
+            "schemaVersion": 1,
+            "name": request.name,
+            "sequence": request.sequence,
+            "unpairedMsa": unpaired_msa,
+            "pairedMsa": paired_msa,
+            "provenance": self._cache_signature(),
+        }
+
+    def _cache_signature(self) -> dict[str, Any]:
+        def database_value(database: DatabaseSpec) -> dict[str, Any]:
+            return {
+                "name": database.name,
+                "identifier": database.identifier,
+                "max_sequences": database.max_sequences
+                or _default_max_sequences(database.name),
+            }
+
+        return {
+            "schema_version": 4,
+            "mmseqs_identity": self._process_identity(),
+            "search_mode": self._search_mode(),
+            "e_value": self._settings.e_value,
+            "unpaired_databases": [
+                database_value(database)
+                for database in self._settings.unpaired_databases
+            ],
+            "paired_database": database_value(self._settings.paired_database),
+        }
+
+    def _search_mode(self) -> str:
+        operation = getattr(self._mmseqs, "search_mode", None)
+        return operation() if operation is not None else "gpu"
+
+    def _process_identity(self) -> str:
+        if self._mmseqs_identity is None:
+            try:
+                identity = self._mmseqs.identity().strip()
+            except (OSError, RuntimeError) as exc:
+                raise RuntimeError(
+                    "Cannot identify the configured MMseqs2 executable; cached MSAs "
+                    f"cannot be trusted and search cannot proceed: {exc}"
+                ) from exc
+            if not identity:
+                raise ValueError("MMseqs2 process identity must not be empty")
+            self._mmseqs_identity = identity
+        return self._mmseqs_identity
+
+    @property
+    def _msa_output_dir(self) -> Path:
+        if isinstance(self._settings, MsaBatchSettings):
+            return self._settings.output_dir
+        return (
+            self._settings.msa_output_dir or self._settings.output_dir / ".mmseqs_msas"
+        )
+
+    def _msa_path(self, name: str) -> Path:
+        return self._msa_output_dir / f"{name}_mmseqs_msa.json"
+
+
+class FeatureFinalizer:
+    """Turn persisted MSA bundles into standard AF3 feature artifacts on CPU."""
+
+    def __init__(
+        self,
+        *,
+        settings: FeatureFinalizationSettings | FeatureBatchSettings,
+        af3_pipeline: Any,
+    ):
+        self._settings = settings
+        self._af3_pipeline = af3_pipeline
+
+    def generate(self, requests: Sequence[FeatureRequest]) -> FeatureBatchResult:
+        requests = tuple(requests)
+        self._validate(requests)
+        self._settings.output_dir.mkdir(parents=True, exist_ok=True)
+        written = []
+        reused = []
+        failures = []
+        for request in requests:
+            try:
+                msa_payload = self._read_msa(request)
+                cached = self._read_matching_artifact(request, msa_payload)
+                if cached is not None:
+                    reused.append(FeatureArtifact(name=request.name, path=cached))
+                    continue
+                payload = self._process_with_af3(request, msa_payload)
+                path = self._artifact_path(request.name)
+                _write_atomic(path, payload)
+                written.append(FeatureArtifact(name=request.name, path=path))
+            except Exception as exc:
+                failures.append(FeatureFailure(name=request.name, error=str(exc)))
+        return FeatureBatchResult(
+            written=tuple(written), reused=tuple(reused), failures=tuple(failures)
+        )
+
+    def _validate(self, requests: Sequence[FeatureRequest]) -> None:
+        _validate_feature_requests(requests)
+        for field_name in (
+            "max_template_date",
+            "template_seqres_database_id",
+            "template_mmcif_database_id",
+        ):
+            if not str(getattr(self._settings, field_name)).strip():
+                raise ValueError(f"{field_name} requires a non-empty value")
+
+    @property
+    def _msa_output_dir(self) -> Path:
+        if isinstance(self._settings, FeatureFinalizationSettings):
+            return self._settings.msa_input_dir
+        return (
+            self._settings.msa_output_dir or self._settings.output_dir / ".mmseqs_msas"
+        )
+
+    def _read_msa(self, request: FeatureRequest) -> dict[str, Any]:
+        path = self._msa_output_dir / f"{request.name}_mmseqs_msa.json"
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Cannot read MMseqs2 MSA bundle {path}: {exc}") from exc
+        if payload.get("sequence") != request.sequence:
+            raise ValueError(
+                f"MMseqs2 MSA bundle sequence does not match {request.name!r}"
+            )
+        if not isinstance(payload.get("provenance"), dict):
+            raise ValueError(
+                f"MMseqs2 MSA bundle lacks provenance for {request.name!r}"
+            )
+        for key in ("unpairedMsa", "pairedMsa"):
+            if not isinstance(payload.get(key), str):
+                raise ValueError(f"MMseqs2 MSA bundle lacks {key} for {request.name!r}")
+        return payload
+
+    def _read_matching_artifact(
+        self, request: FeatureRequest, msa_payload: Mapping[str, Any]
+    ) -> Path | None:
+        path = self._artifact_path(request.name)
+        if not path.exists():
+            return None
+        try:
+            opener = lzma.open if path.suffix == ".xz" else open
+            with opener(path, "rt", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            protein = payload["sequences"][0]["protein"]
+            metadata = extract_metadata_from_af3_json(payload)
+            if protein.get("sequence") != request.sequence or not metadata:
+                return None
+            other = metadata[0].get("other", {})
+            if other.get("mmseqs2_gpu") != msa_payload["provenance"]:
+                return None
+            if other.get("af3_templates") != self._template_signature():
+                return None
+            return path
+        except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+    def _process_with_af3(
+        self, request: FeatureRequest, msa_payload: Mapping[str, Any]
     ) -> dict[str, Any]:
         from alphafold3.common import folding_input
 
@@ -489,8 +745,9 @@ class FeatureBatch:
                         "id": "A",
                         "sequence": request.sequence,
                         "description": request.name,
-                        "unpairedMsa": unpaired_msa,
-                        "pairedMsa": paired_msa,
+                        "unpairedMsa": msa_payload["unpairedMsa"],
+                        "pairedMsa": msa_payload["pairedMsa"],
+                        # Native AF3 searches templates from the merged unpaired MSA.
                         "templates": None,
                     }
                 }
@@ -502,65 +759,82 @@ class FeatureBatch:
         processed = self._af3_pipeline.process(fold_input)
         payload = json.loads(processed.to_json())
         payload["name"] = request.name
-        return embed_metadata_in_af3_json(payload, self._metadata())
-
-    def _metadata(self) -> dict[str, Any]:
         metadata = copy.deepcopy(dict(self._settings.base_metadata))
         other = metadata.setdefault("other", {})
         other["msa_backend"] = "mmseqs2-gpu"
-        other["mmseqs2_gpu"] = self._cache_signature()
-        return metadata
+        other["mmseqs2_gpu"] = msa_payload["provenance"]
+        other["af3_templates"] = self._template_signature()
+        return embed_metadata_in_af3_json(payload, metadata)
 
-    def _cache_signature(self) -> dict[str, Any]:
-        def database_value(database: DatabaseSpec) -> dict[str, Any]:
-            return {
-                "name": database.name,
-                "identifier": database.identifier,
-                "max_sequences": database.max_sequences
-                or _default_max_sequences(database.name),
-            }
-
+    def _template_signature(self) -> dict[str, str | int]:
         return {
-            "schema_version": 3,
-            "mmseqs_identity": self._process_identity(),
-            "sensitivity": self._settings.sensitivity,
-            "e_value": self._settings.e_value,
-            "unpaired_databases": [
-                database_value(database)
-                for database in self._settings.unpaired_databases
-            ],
-            "paired_database": database_value(self._settings.paired_database),
+            "schema_version": 1,
+            "max_template_date": self._settings.max_template_date,
+            "pdb_seqres_database_id": self._settings.template_seqres_database_id,
+            "mmcif_database_id": self._settings.template_mmcif_database_id,
         }
-
-    def _process_identity(self) -> str:
-        if self._mmseqs_identity is None:
-            identity = self._mmseqs.identity().strip()
-            if not identity:
-                raise ValueError("MMseqs2 process identity must not be empty")
-            self._mmseqs_identity = identity
-        return self._mmseqs_identity
 
     def _artifact_path(self, name: str) -> Path:
         suffix = "_af3_input.json.xz" if self._settings.compress else "_af3_input.json"
         return self._settings.output_dir / f"{name}{suffix}"
 
-    @staticmethod
-    def _write_atomic(path: Path, payload: Mapping[str, Any]) -> None:
-        text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
-        descriptor, temporary_name = tempfile.mkstemp(
-            prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+
+class FeatureBatch:
+    """Compatibility facade that composes GPU MSA and CPU AF3 stages."""
+
+    def __init__(
+        self,
+        *,
+        settings: FeatureBatchSettings,
+        mmseqs_process: MmseqsProcess,
+        af3_pipeline: Any,
+    ):
+        self._msa_batch = MsaBatch(
+            settings=settings,
+            mmseqs_process=mmseqs_process,
         )
-        os.close(descriptor)
-        temporary_path = Path(temporary_name)
-        try:
+        self._finalizer = FeatureFinalizer(
+            settings=settings,
+            af3_pipeline=af3_pipeline,
+        )
+
+    def generate(self, requests: Sequence[FeatureRequest]) -> FeatureBatchResult:
+        msa_result = self._msa_batch.generate(requests)
+        failed_names = {failure.name for failure in msa_result.failures}
+        final_result = self._finalizer.generate(
+            [request for request in requests if request.name not in failed_names]
+        )
+        return FeatureBatchResult(
+            written=final_result.written,
+            reused=final_result.reused,
+            failures=(*msa_result.failures, *final_result.failures),
+        )
+
+
+def _write_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    """Durably publish JSON so completed cache entries survive worker failure."""
+    text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as raw_handle:
             if path.suffix == ".xz":
-                with lzma.open(temporary_path, "wt", encoding="utf-8") as handle:
+                with lzma.open(raw_handle, "wt", encoding="utf-8") as handle:
                     handle.write(text)
             else:
-                temporary_path.write_text(text, encoding="utf-8")
-            os.replace(temporary_path, path)
+                raw_handle.write(text.encode("utf-8"))
+            raw_handle.flush()
+            os.fsync(raw_handle.fileno())
+        os.replace(temporary_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
         finally:
-            temporary_path.unlink(missing_ok=True)
+            os.close(directory_fd)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
 
 def _fasta_records(fasta: str) -> list[tuple[str, str]]:
@@ -592,7 +866,9 @@ def _aligned_fasta_to_a3m(aligned_fasta: str, query_sequence: str) -> str:
         query_alignment.replace("-", "").replace(".", "").upper()
         != query_sequence.upper()
     ):
-        raise ValueError("MMseqs2 aligned FASTA query does not match its input sequence")
+        raise ValueError(
+            "MMseqs2 aligned FASTA query does not match its input sequence"
+        )
 
     converted = []
     for description, sequence in records:

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -179,7 +179,7 @@ class SubprocessMmseqsProcess:
                 str(result_db),
                 str(msa_db),
                 "--msa-format-mode",
-                "6",
+                "2",
             )
         )
 
@@ -193,7 +193,7 @@ class SubprocessMmseqsProcess:
                 "--unpack-name-mode",
                 "0",
                 "--unpack-suffix",
-                ".a3m",
+                ".fasta",
             )
         )
 
@@ -457,15 +457,20 @@ class FeatureBatch:
             if query_id not in query_ids:
                 continue
             candidates = (
+                output_dir / f"{index}.fasta",
                 output_dir / f"{index}.a3m",
                 output_dir / index,
+                output_dir / f"{query_id}.fasta",
                 output_dir / f"{query_id}.a3m",
             )
             result_path = next((path for path in candidates if path.exists()), None)
             if result_path is None:
                 results[query_id] = f">query\n{query_ids[query_id]}\n"
             else:
-                results[query_id] = result_path.read_text(encoding="utf-8")
+                results[query_id] = _aligned_fasta_to_a3m(
+                    result_path.read_text(encoding="utf-8"),
+                    query_ids[query_id],
+                )
         for query_id, sequence in query_ids.items():
             results.setdefault(query_id, f">query\n{sequence}\n")
         return results
@@ -516,7 +521,7 @@ class FeatureBatch:
             }
 
         return {
-            "schema_version": 2,
+            "schema_version": 3,
             "mmseqs_identity": self._process_identity(),
             "sensitivity": self._settings.sensitivity,
             "e_value": self._settings.e_value,
@@ -558,11 +563,11 @@ class FeatureBatch:
             temporary_path.unlink(missing_ok=True)
 
 
-def _a3m_records(a3m: str) -> list[tuple[str, str]]:
+def _fasta_records(fasta: str) -> list[tuple[str, str]]:
     records = []
     description = None
     sequence_parts = []
-    for line in a3m.splitlines():
+    for line in fasta.splitlines():
         if line.startswith(">"):
             if description is not None:
                 records.append((description, "".join(sequence_parts)))
@@ -575,8 +580,32 @@ def _a3m_records(a3m: str) -> list[tuple[str, str]]:
     return records
 
 
+def _aligned_fasta_to_a3m(aligned_fasta: str, query_sequence: str) -> str:
+    """Remove query-gap columns while retaining insertions and full headers."""
+    from alphafold3.cpp import msa_conversion
+
+    records = _fasta_records(aligned_fasta)
+    if not records:
+        return f">query\n{query_sequence}\n"
+    query_alignment = records[0][1]
+    if (
+        query_alignment.replace("-", "").replace(".", "").upper()
+        != query_sequence.upper()
+    ):
+        raise ValueError("MMseqs2 aligned FASTA query does not match its input sequence")
+
+    converted = []
+    for description, sequence in records:
+        a3m_sequence = msa_conversion.align_sequence_to_gapless_query(
+            sequence=sequence,
+            query_sequence=query_alignment,
+        ).replace(".", "")
+        converted.append(f">{description}\n{a3m_sequence}\n")
+    return "".join(converted)
+
+
 def _normalise_query(a3m: str, query_sequence: str) -> str:
-    records = _a3m_records(a3m)
+    records = _fasta_records(a3m)
     if not records:
         return f">query\n{query_sequence}\n"
     records[0] = ("query", query_sequence)
@@ -587,7 +616,7 @@ def _merge_a3ms(query_sequence: str, a3ms: Sequence[str]) -> str:
     rows = [("query", query_sequence)]
     seen = {query_sequence}
     for a3m in a3ms:
-        for _, (description, sequence) in enumerate(_a3m_records(a3m)):
+        for _, (description, sequence) in enumerate(_fasta_records(a3m)):
             if sequence in seen:
                 continue
             seen.add(sequence)

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -283,7 +283,9 @@ class SubprocessMmseqsProcess:
         return version
 
     def search_mode(self) -> str:
-        return "gpu" if self._gpu else "cpu-contract"
+        # Recorded in each bundle's provenance: CPU and GPU search are both supported and
+        # a cached result should not be reused across the two.
+        return "gpu" if self._gpu else "cpu"
 
     def create_query_database(self, query_fasta: Path, query_db: Path) -> None:
         self._run(("createdb", str(query_fasta), str(query_db)))

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -961,7 +961,7 @@ def _aligned_fasta_to_a3m(aligned_fasta: str, query_sequence: str) -> str:
 def _normalise_query(a3m: str, query_sequence: str) -> str:
     records = _fasta_records(a3m)
     if not records:
-        return f">query\n{query_sequence}\n"
+        raise ValueError("MMseqs2 A3M contains no records")
     records[0] = ("query", query_sequence)
     return "".join(f">{description}\n{sequence}\n" for description, sequence in records)
 

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -160,6 +160,7 @@ class FeatureBatchResult:
     written: tuple[FeatureArtifact, ...]
     reused: tuple[FeatureArtifact, ...]
     failures: tuple[FeatureFailure, ...]
+    query_only: tuple[str, ...] = ()
 
 
 class _InvalidMsaBundle(ValueError):
@@ -921,6 +922,7 @@ class FeatureBatch:
         return FeatureBatchResult(
             written=final_result.written,
             reused=final_result.reused,
+            query_only=msa_result.query_only,
             failures=(
                 *(
                     FeatureFailure(name=failure.name, error=failure.error)

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -13,6 +13,8 @@ import subprocess
 import tempfile
 from typing import Any, Mapping, Protocol, Sequence
 
+from absl import logging
+
 from alphapulldown.utils.feature_metadata import (
     embed_metadata_in_af3_json,
     extract_metadata_from_af3_json,
@@ -138,6 +140,7 @@ class MsaBatchResult:
     written: tuple[MsaArtifact, ...]
     reused: tuple[MsaArtifact, ...]
     failures: tuple[MsaFailure, ...]
+    query_only: tuple[str, ...] = ()
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -428,8 +431,41 @@ class MsaBatch:
                 for request in sequence_to_requests[sequence]
             )
 
+        # A search that returned nothing yields a query-only MSA. That is legitimate for
+        # an orphan sequence but is also exactly what a misconfigured or half-built
+        # database produces, and the two are indistinguishable from provenance alone -
+        # so make it visible instead of recording it as an ordinary success.
+        query_only = []
+        for artifact in (*written, *reused):
+            depths = self._artifact_depths(artifact.path)
+            if depths is not None and max(depths) <= 1:
+                query_only.append(artifact.name)
+                logging.warning(
+                    "MMseqs2 returned no hits for %s: the MSA contains only the query. "
+                    "Check the configured databases before using this artifact.",
+                    artifact.name,
+                )
         return MsaBatchResult(
-            written=tuple(written), reused=tuple(reused), failures=tuple(failures)
+            written=tuple(written),
+            reused=tuple(reused),
+            failures=tuple(failures),
+            query_only=tuple(query_only),
+        )
+
+    @staticmethod
+    def _artifact_depths(path: Path) -> tuple[int, int] | None:
+        try:
+            with open(path, "rt", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, ValueError):
+            return None
+        unpaired = payload.get("unpairedDepth")
+        paired = payload.get("pairedDepth")
+        if isinstance(unpaired, int) and isinstance(paired, int):
+            return unpaired, paired
+        return (
+            _msa_depth(payload.get("unpairedMsa", "")),
+            _msa_depth(payload.get("pairedMsa", "")),
         )
 
     def _read_matching_msa(
@@ -626,11 +662,13 @@ class MsaBatch:
         self, request: FeatureRequest, unpaired_msa: str, paired_msa: str
     ) -> dict[str, Any]:
         return {
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "name": request.name,
             "sequence": request.sequence,
             "unpairedMsa": unpaired_msa,
             "pairedMsa": paired_msa,
+            "unpairedDepth": _msa_depth(unpaired_msa),
+            "pairedDepth": _msa_depth(paired_msa),
             "provenance": self._cache_signature(),
         }
 
@@ -641,6 +679,10 @@ class MsaBatch:
                 "identifier": database.identifier,
                 "max_sequences": database.max_sequences
                 or _default_max_sequences(database.name),
+                # `identifier` is operator-supplied, so it cannot detect a database that
+                # was rebuilt, truncated or half-copied under the same name. The index
+                # size is a cheap content-derived witness that changes when it does.
+                "index_size": _database_index_size(database.path),
             }
 
         return {
@@ -913,6 +955,19 @@ def _write_atomic(path: Path, payload: Mapping[str, Any]) -> None:
             os.close(directory_fd)
     finally:
         temporary_path.unlink(missing_ok=True)
+
+
+def _database_index_size(path: Path) -> int:
+    """Size of an MMseqs2 database index, or 0 when it cannot be read."""
+    try:
+        return Path(f"{path}.index").stat().st_size
+    except OSError:
+        return 0
+
+
+def _msa_depth(a3m: str) -> int:
+    """Number of alignment rows, including the query."""
+    return sum(1 for line in a3m.splitlines() if line.startswith(">"))
 
 
 def _fasta_records(fasta: str) -> list[tuple[str, str]]:

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -78,6 +78,8 @@ class FeatureBatchResult:
 class MmseqsProcess(Protocol):
     """Process operations performed by the external MMseqs2 executable."""
 
+    def identity(self) -> str: ...
+
     def create_query_database(self, query_fasta: Path, query_db: Path) -> None: ...
 
     def search(
@@ -106,9 +108,9 @@ class SubprocessMmseqsProcess:
     def __init__(self, binary_path: str | Path):
         self._binary_path = str(binary_path)
 
-    def _run(self, command: Sequence[str]) -> None:
+    def _run(self, command: Sequence[str]) -> str:
         try:
-            subprocess.run(
+            completed = subprocess.run(
                 [self._binary_path, *command],
                 check=True,
                 stdout=subprocess.PIPE,
@@ -120,6 +122,14 @@ class SubprocessMmseqsProcess:
             raise RuntimeError(
                 f"MMseqs2 command failed: {' '.join(command)}\n{stderr.strip()}"
             ) from exc
+        return completed.stdout.strip()
+
+    def identity(self) -> str:
+        """Return the executable version used to validate persisted artifacts."""
+        version = " ".join(self._run(("version",)).split())
+        if not version:
+            raise RuntimeError("MMseqs2 version command returned no identity")
+        return version
 
     def create_query_database(self, query_fasta: Path, query_db: Path) -> None:
         self._run(("createdb", str(query_fasta), str(query_db)))
@@ -210,6 +220,7 @@ class FeatureBatch:
         self._settings = settings
         self._mmseqs = mmseqs_process
         self._af3_pipeline = af3_pipeline
+        self._mmseqs_identity: str | None = None
 
     def generate(self, requests: Sequence[FeatureRequest]) -> FeatureBatchResult:
         requests = tuple(requests)
@@ -505,7 +516,8 @@ class FeatureBatch:
             }
 
         return {
-            "schema_version": 1,
+            "schema_version": 2,
+            "mmseqs_identity": self._process_identity(),
             "sensitivity": self._settings.sensitivity,
             "e_value": self._settings.e_value,
             "unpaired_databases": [
@@ -514,6 +526,14 @@ class FeatureBatch:
             ],
             "paired_database": database_value(self._settings.paired_database),
         }
+
+    def _process_identity(self) -> str:
+        if self._mmseqs_identity is None:
+            identity = self._mmseqs.identity().strip()
+            if not identity:
+                raise ValueError("MMseqs2 process identity must not be empty")
+            self._mmseqs_identity = identity
+        return self._mmseqs_identity
 
     def _artifact_path(self, name: str) -> Path:
         suffix = "_af3_input.json.xz" if self._settings.compress else "_af3_input.json"

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import hashlib
 import json
 import lzma
 import os
@@ -119,6 +120,27 @@ class FeatureBatchSettings:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
+class MsaArtifact:
+    """One durable per-protein MSA bundle."""
+
+    name: str
+    path: Path
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MsaFailure:
+    name: str
+    error: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MsaBatchResult:
+    written: tuple[MsaArtifact, ...]
+    reused: tuple[MsaArtifact, ...]
+    failures: tuple[MsaFailure, ...]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
 class FeatureArtifact:
     name: str
     path: Path
@@ -137,19 +159,40 @@ class FeatureBatchResult:
     failures: tuple[FeatureFailure, ...]
 
 
-def write_batch_summary(path: Path, result: FeatureBatchResult) -> None:
+class _InvalidMsaBundle(ValueError):
+    """An on-disk MSA bundle whose contents are unsafe to reuse."""
+
+
+def write_batch_summary(path: Path, result: MsaBatchResult) -> None:
     """Atomically publish a completion record for an entirely successful stage."""
     if result.failures:
         raise ValueError("A completion summary cannot represent a failed batch")
+    artifacts = (*result.written, *result.reused)
     path.parent.mkdir(parents=True, exist_ok=True)
     _write_atomic(
         path,
         {
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "written": [artifact.name for artifact in result.written],
             "reused": [artifact.name for artifact in result.reused],
+            "artifacts": [_manifest_record(artifact) for artifact in artifacts],
         },
     )
+
+
+def _manifest_record(artifact: MsaArtifact) -> dict[str, Any]:
+    digest = hashlib.sha256()
+    with artifact.path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    stat = artifact.path.stat()
+    return {
+        "name": artifact.name,
+        "file": artifact.path.name,
+        "sizeBytes": stat.st_size,
+        "mtimeNs": stat.st_mtime_ns,
+        "sha256": digest.hexdigest(),
+    }
 
 
 class MmseqsProcess(Protocol):
@@ -167,7 +210,7 @@ class MmseqsProcess(Protocol):
         database: DatabaseSpec,
         result_db: Path,
         work_dir: Path,
-        settings: MsaBatchSettings | FeatureBatchSettings,
+        settings: MsaBatchSettings,
     ) -> None: ...
 
     def result_to_msa(
@@ -223,7 +266,7 @@ class SubprocessMmseqsProcess:
         database: DatabaseSpec,
         result_db: Path,
         work_dir: Path,
-        settings: MsaBatchSettings | FeatureBatchSettings,
+        settings: MsaBatchSettings,
     ) -> None:
         max_sequences = database.max_sequences or _default_max_sequences(database.name)
         self._run(
@@ -294,17 +337,19 @@ class MsaBatch:
     def __init__(
         self,
         *,
-        settings: MsaBatchSettings | FeatureBatchSettings,
+        settings: MsaBatchSettings,
         mmseqs_process: MmseqsProcess,
     ):
+        if not isinstance(settings, MsaBatchSettings):
+            raise TypeError("MsaBatch settings must be MsaBatchSettings")
         self._settings = settings
         self._mmseqs = mmseqs_process
         self._mmseqs_identity: str | None = None
 
-    def generate(self, requests: Sequence[FeatureRequest]) -> FeatureBatchResult:
+    def generate(self, requests: Sequence[FeatureRequest]) -> MsaBatchResult:
         requests = tuple(requests)
         self._validate(requests)
-        self._msa_output_dir.mkdir(parents=True, exist_ok=True)
+        self._settings.output_dir.mkdir(parents=True, exist_ok=True)
         self._settings.temp_dir.mkdir(parents=True, exist_ok=True)
 
         reused = []
@@ -316,7 +361,7 @@ class MsaBatch:
                 missing_requests.append(request)
                 continue
             path, payload = cached
-            reused.append(FeatureArtifact(name=request.name, path=path))
+            reused.append(MsaArtifact(name=request.name, path=path))
             msa_by_sequence.setdefault(
                 request.sequence,
                 (payload["unpairedMsa"], payload["pairedMsa"]),
@@ -338,9 +383,9 @@ class MsaBatch:
                     payload = self._msa_payload(request, *cached_msas)
                     path = self._msa_path(request.name)
                     _write_atomic(path, payload)
-                    written.append(FeatureArtifact(name=request.name, path=path))
+                    written.append(MsaArtifact(name=request.name, path=path))
                 except Exception as exc:
-                    failures.append(FeatureFailure(name=request.name, error=str(exc)))
+                    failures.append(MsaFailure(name=request.name, error=str(exc)))
 
         sequences_to_search = tuple(
             sequence
@@ -371,19 +416,19 @@ class MsaBatch:
                         payload = self._msa_payload(request, *msas)
                         path = self._msa_path(request.name)
                         _write_atomic(path, payload)
-                        written.append(FeatureArtifact(name=request.name, path=path))
+                        written.append(MsaArtifact(name=request.name, path=path))
                     except Exception as exc:
                         failures.append(
-                            FeatureFailure(name=request.name, error=str(exc))
+                            MsaFailure(name=request.name, error=str(exc))
                         )
 
         for sequence, error in search_errors.items():
             failures.extend(
-                FeatureFailure(name=request.name, error=error)
+                MsaFailure(name=request.name, error=error)
                 for request in sequence_to_requests[sequence]
             )
 
-        return FeatureBatchResult(
+        return MsaBatchResult(
             written=tuple(written), reused=tuple(reused), failures=tuple(failures)
         )
 
@@ -560,9 +605,14 @@ class MsaBatch:
                     "MMseqs2 unpackdb did not produce an alignment for "
                     f"{query_id!r} in {output_dir.parent.name!r}"
                 )
+            aligned_fasta = result_path.read_text(encoding="utf-8")
+            if not _fasta_records(aligned_fasta):
+                raise RuntimeError(
+                    "MMseqs2 unpackdb produced no FASTA records for "
+                    f"{query_id!r} in {output_dir.parent.name!r}"
+                )
             results[query_id] = _aligned_fasta_to_a3m(
-                result_path.read_text(encoding="utf-8"),
-                query_ids[query_id],
+                aligned_fasta, query_ids[query_id]
             )
         missing_queries = set(query_ids) - set(results)
         if missing_queries:
@@ -623,16 +673,8 @@ class MsaBatch:
             self._mmseqs_identity = identity
         return self._mmseqs_identity
 
-    @property
-    def _msa_output_dir(self) -> Path:
-        if isinstance(self._settings, MsaBatchSettings):
-            return self._settings.output_dir
-        return (
-            self._settings.msa_output_dir or self._settings.output_dir / ".mmseqs_msas"
-        )
-
     def _msa_path(self, name: str) -> Path:
-        return self._msa_output_dir / f"{name}_mmseqs_msa.json"
+        return self._settings.output_dir / f"{name}_mmseqs_msa.json"
 
 
 class FeatureFinalizer:
@@ -641,9 +683,13 @@ class FeatureFinalizer:
     def __init__(
         self,
         *,
-        settings: FeatureFinalizationSettings | FeatureBatchSettings,
+        settings: FeatureFinalizationSettings,
         af3_pipeline: Any,
     ):
+        if not isinstance(settings, FeatureFinalizationSettings):
+            raise TypeError(
+                "FeatureFinalizer settings must be FeatureFinalizationSettings"
+            )
         self._settings = settings
         self._af3_pipeline = af3_pipeline
 
@@ -681,32 +727,40 @@ class FeatureFinalizer:
             if not str(getattr(self._settings, field_name)).strip():
                 raise ValueError(f"{field_name} requires a non-empty value")
 
-    @property
-    def _msa_output_dir(self) -> Path:
-        if isinstance(self._settings, FeatureFinalizationSettings):
-            return self._settings.msa_input_dir
-        return (
-            self._settings.msa_output_dir or self._settings.output_dir / ".mmseqs_msas"
-        )
-
     def _read_msa(self, request: FeatureRequest) -> dict[str, Any]:
-        path = self._msa_output_dir / f"{request.name}_mmseqs_msa.json"
+        path = self._settings.msa_input_dir / f"{request.name}_mmseqs_msa.json"
         try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            encoded = path.read_text(encoding="utf-8")
+        except OSError as exc:
             raise RuntimeError(f"Cannot read MMseqs2 MSA bundle {path}: {exc}") from exc
-        if payload.get("sequence") != request.sequence:
-            raise ValueError(
-                f"MMseqs2 MSA bundle sequence does not match {request.name!r}"
-            )
-        if not isinstance(payload.get("provenance"), dict):
-            raise ValueError(
-                f"MMseqs2 MSA bundle lacks provenance for {request.name!r}"
-            )
-        for key in ("unpairedMsa", "pairedMsa"):
-            if not isinstance(payload.get(key), str):
-                raise ValueError(f"MMseqs2 MSA bundle lacks {key} for {request.name!r}")
-        return payload
+        try:
+            try:
+                payload = json.loads(encoded)
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise _InvalidMsaBundle(
+                    f"Cannot parse MMseqs2 MSA bundle {path}: {exc}"
+                ) from exc
+            if not isinstance(payload, dict):
+                raise _InvalidMsaBundle(
+                    f"MMseqs2 MSA bundle {path} is not a JSON object"
+                )
+            if payload.get("sequence") != request.sequence:
+                raise _InvalidMsaBundle(
+                    f"MMseqs2 MSA bundle sequence does not match {request.name!r}"
+                )
+            if not isinstance(payload.get("provenance"), dict):
+                raise _InvalidMsaBundle(
+                    f"MMseqs2 MSA bundle lacks provenance for {request.name!r}"
+                )
+            for key in ("unpairedMsa", "pairedMsa"):
+                if not isinstance(payload.get(key), str):
+                    raise _InvalidMsaBundle(
+                        f"MMseqs2 MSA bundle lacks {key} for {request.name!r}"
+                    )
+            return payload
+        except _InvalidMsaBundle:
+            path.unlink(missing_ok=True)
+            raise
 
     def _read_matching_artifact(
         self, request: FeatureRequest, msa_payload: Mapping[str, Any]
@@ -789,12 +843,30 @@ class FeatureBatch:
         mmseqs_process: MmseqsProcess,
         af3_pipeline: Any,
     ):
+        msa_output_dir = settings.msa_output_dir or settings.output_dir / ".mmseqs_msas"
         self._msa_batch = MsaBatch(
-            settings=settings,
+            settings=MsaBatchSettings(
+                output_dir=msa_output_dir,
+                temp_dir=settings.temp_dir,
+                unpaired_databases=settings.unpaired_databases,
+                paired_database=settings.paired_database,
+                max_sequences_per_batch=settings.max_sequences_per_batch,
+                max_residues_per_batch=settings.max_residues_per_batch,
+                threads=settings.threads,
+                e_value=settings.e_value,
+            ),
             mmseqs_process=mmseqs_process,
         )
         self._finalizer = FeatureFinalizer(
-            settings=settings,
+            settings=FeatureFinalizationSettings(
+                output_dir=settings.output_dir,
+                msa_input_dir=msa_output_dir,
+                max_template_date=settings.max_template_date,
+                template_seqres_database_id=settings.template_seqres_database_id,
+                template_mmcif_database_id=settings.template_mmcif_database_id,
+                compress=settings.compress,
+                base_metadata=settings.base_metadata,
+            ),
             af3_pipeline=af3_pipeline,
         )
 
@@ -807,7 +879,13 @@ class FeatureBatch:
         return FeatureBatchResult(
             written=final_result.written,
             reused=final_result.reused,
-            failures=(*msa_result.failures, *final_result.failures),
+            failures=(
+                *(
+                    FeatureFailure(name=failure.name, error=failure.error)
+                    for failure in msa_result.failures
+                ),
+                *final_result.failures,
+            ),
         )
 
 
@@ -860,7 +938,7 @@ def _aligned_fasta_to_a3m(aligned_fasta: str, query_sequence: str) -> str:
 
     records = _fasta_records(aligned_fasta)
     if not records:
-        return f">query\n{query_sequence}\n"
+        raise ValueError("MMseqs2 aligned FASTA contains no records")
     query_alignment = records[0][1]
     if (
         query_alignment.replace("-", "").replace(".", "").upper()

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -1,0 +1,575 @@
+"""Batched local MMseqs2-GPU feature generation for AlphaFold 3 proteins."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import json
+import lzma
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Any, Mapping, Protocol, Sequence
+
+from alphapulldown.utils.feature_metadata import (
+    embed_metadata_in_af3_json,
+    extract_metadata_from_af3_json,
+)
+
+
+_PROTEIN_RESIDUES = frozenset("ACDEFGHIKLMNPQRSTVWYX")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FeatureRequest:
+    """One named protein sequence requiring an AF3 feature artifact."""
+
+    name: str
+    sequence: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DatabaseSpec:
+    """An explicit MMseqs2 database and its immutable cache identity."""
+
+    name: str
+    path: Path
+    identifier: str
+    max_sequences: int | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FeatureBatchSettings:
+    """Settings that determine batching, search results, and persistence."""
+
+    output_dir: Path
+    temp_dir: Path
+    unpaired_databases: tuple[DatabaseSpec, ...]
+    paired_database: DatabaseSpec
+    max_sequences_per_batch: int
+    max_residues_per_batch: int
+    threads: int
+    sensitivity: float = 7.5
+    e_value: float = 1e-4
+    compress: bool = False
+    base_metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FeatureArtifact:
+    name: str
+    path: Path
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FeatureFailure:
+    name: str
+    error: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FeatureBatchResult:
+    written: tuple[FeatureArtifact, ...]
+    reused: tuple[FeatureArtifact, ...]
+    failures: tuple[FeatureFailure, ...]
+
+
+class MmseqsProcess(Protocol):
+    """Process operations performed by the external MMseqs2 executable."""
+
+    def create_query_database(self, query_fasta: Path, query_db: Path) -> None: ...
+
+    def search(
+        self,
+        query_db: Path,
+        database: DatabaseSpec,
+        result_db: Path,
+        work_dir: Path,
+        settings: FeatureBatchSettings,
+    ) -> None: ...
+
+    def result_to_msa(
+        self,
+        query_db: Path,
+        database: DatabaseSpec,
+        result_db: Path,
+        msa_db: Path,
+    ) -> None: ...
+
+    def unpack_msa(self, query_db: Path, msa_db: Path, output_dir: Path) -> None: ...
+
+
+class SubprocessMmseqsProcess:
+    """Production adapter for one local MMseqs2 executable."""
+
+    def __init__(self, binary_path: str | Path):
+        self._binary_path = str(binary_path)
+
+    def _run(self, command: Sequence[str]) -> None:
+        try:
+            subprocess.run(
+                [self._binary_path, *command],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            stderr = getattr(exc, "stderr", "") or ""
+            raise RuntimeError(
+                f"MMseqs2 command failed: {' '.join(command)}\n{stderr.strip()}"
+            ) from exc
+
+    def create_query_database(self, query_fasta: Path, query_db: Path) -> None:
+        self._run(("createdb", str(query_fasta), str(query_db)))
+
+    def search(
+        self,
+        query_db: Path,
+        database: DatabaseSpec,
+        result_db: Path,
+        work_dir: Path,
+        settings: FeatureBatchSettings,
+    ) -> None:
+        max_sequences = database.max_sequences or _default_max_sequences(database.name)
+        self._run(
+            (
+                "search",
+                str(query_db),
+                str(database.path),
+                str(result_db),
+                str(work_dir),
+                "-a",
+                "-s",
+                str(settings.sensitivity),
+                "-e",
+                str(settings.e_value),
+                "--threads",
+                str(settings.threads),
+                "--max-seqs",
+                str(max_sequences),
+                "--gpu",
+                "1",
+            )
+        )
+
+    def result_to_msa(
+        self,
+        query_db: Path,
+        database: DatabaseSpec,
+        result_db: Path,
+        msa_db: Path,
+    ) -> None:
+        self._run(
+            (
+                "result2msa",
+                str(query_db),
+                str(database.path),
+                str(result_db),
+                str(msa_db),
+                "--msa-format-mode",
+                "6",
+            )
+        )
+
+    def unpack_msa(self, query_db: Path, msa_db: Path, output_dir: Path) -> None:
+        del query_db
+        self._run(
+            (
+                "unpackdb",
+                str(msa_db),
+                str(output_dir),
+                "--unpack-name-mode",
+                "0",
+                "--unpack-suffix",
+                ".a3m",
+            )
+        )
+
+
+def _default_max_sequences(database_name: str) -> int:
+    return {
+        "uniref90": 10_000,
+        "mgnify": 5_000,
+        "small_bfd": 5_000,
+        "uniprot": 50_000,
+    }.get(database_name, 5_000)
+
+
+class FeatureBatch:
+    """Generate many independent AF3 protein artifacts behind one interface."""
+
+    def __init__(
+        self,
+        *,
+        settings: FeatureBatchSettings,
+        mmseqs_process: MmseqsProcess,
+        af3_pipeline: Any,
+    ):
+        self._settings = settings
+        self._mmseqs = mmseqs_process
+        self._af3_pipeline = af3_pipeline
+
+    def generate(self, requests: Sequence[FeatureRequest]) -> FeatureBatchResult:
+        requests = tuple(requests)
+        self._validate(requests)
+        self._settings.output_dir.mkdir(parents=True, exist_ok=True)
+        self._settings.temp_dir.mkdir(parents=True, exist_ok=True)
+
+        reused = []
+        missing_requests = []
+        msa_by_sequence: dict[str, tuple[str, str]] = {}
+        for request in requests:
+            cached = self._read_matching_artifact(request)
+            if cached is None:
+                missing_requests.append(request)
+                continue
+            path, payload = cached
+            reused.append(FeatureArtifact(name=request.name, path=path))
+            protein = payload["sequences"][0]["protein"]
+            msa_by_sequence.setdefault(
+                request.sequence,
+                (protein["unpairedMsa"], protein["pairedMsa"]),
+            )
+
+        sequence_to_requests: dict[str, list[FeatureRequest]] = {}
+        for request in missing_requests:
+            sequence_to_requests.setdefault(request.sequence, []).append(request)
+
+        sequences_to_search = tuple(
+            sequence
+            for sequence in sequence_to_requests
+            if sequence not in msa_by_sequence
+        )
+        search_errors: dict[str, str] = {}
+        for chunk in self._pack(sequences_to_search):
+            try:
+                msa_by_sequence.update(self._search_chunk(chunk))
+            except Exception as exc:
+                for sequence in chunk:
+                    search_errors[sequence] = str(exc)
+
+        written = []
+        failures = []
+        for request in missing_requests:
+            if request.sequence in search_errors:
+                failures.append(
+                    FeatureFailure(
+                        name=request.name, error=search_errors[request.sequence]
+                    )
+                )
+                continue
+            try:
+                unpaired_msa, paired_msa = msa_by_sequence[request.sequence]
+                payload = self._process_with_af3(request, unpaired_msa, paired_msa)
+                path = self._artifact_path(request.name)
+                self._write_atomic(path, payload)
+                written.append(FeatureArtifact(name=request.name, path=path))
+            except Exception as exc:  # one bad sequence must not hide other outputs
+                failures.append(FeatureFailure(name=request.name, error=str(exc)))
+
+        return FeatureBatchResult(
+            written=tuple(written), reused=tuple(reused), failures=tuple(failures)
+        )
+
+    def _read_matching_artifact(
+        self, request: FeatureRequest
+    ) -> tuple[Path, dict[str, Any]] | None:
+        path = self._artifact_path(request.name)
+        if not path.exists():
+            return None
+        try:
+            opener = lzma.open if path.suffix == ".xz" else open
+            with opener(path, "rt", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            protein = payload["sequences"][0]["protein"]
+            metadata = extract_metadata_from_af3_json(payload)
+            if protein.get("sequence") != request.sequence or not metadata:
+                return None
+            if (
+                metadata[0].get("other", {}).get("mmseqs2_gpu")
+                != self._cache_signature()
+            ):
+                return None
+            if not isinstance(protein.get("unpairedMsa"), str) or not isinstance(
+                protein.get("pairedMsa"), str
+            ):
+                return None
+            return path, payload
+        except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+    def _validate(self, requests: Sequence[FeatureRequest]) -> None:
+        names = [request.name for request in requests]
+        if len(set(names)) != len(names):
+            raise ValueError("Feature request names must be unique")
+        for request in requests:
+            if not request.name or Path(request.name).name != request.name:
+                raise ValueError(f"Invalid feature request name: {request.name!r}")
+            sequence = request.sequence.upper()
+            if not sequence or set(sequence) - _PROTEIN_RESIDUES:
+                raise ValueError(
+                    f"Feature request {request.name!r} is not a protein sequence"
+                )
+        if self._settings.max_sequences_per_batch < 1:
+            raise ValueError("max_sequences_per_batch must be at least 1")
+        if self._settings.max_residues_per_batch < 1:
+            raise ValueError("max_residues_per_batch must be at least 1")
+        if self._settings.threads < 1:
+            raise ValueError("threads must be at least 1")
+        if self._settings.sensitivity <= 0:
+            raise ValueError("sensitivity must be greater than 0")
+        if self._settings.e_value <= 0:
+            raise ValueError("e_value must be greater than 0")
+        unpaired_names = tuple(
+            database.name for database in self._settings.unpaired_databases
+        )
+        if unpaired_names != ("uniref90", "mgnify", "small_bfd"):
+            raise ValueError(
+                "unpaired_databases must explicitly provide uniref90, mgnify, "
+                "and small_bfd in that order"
+            )
+        if self._settings.paired_database.name != "uniprot":
+            raise ValueError("paired_database must explicitly provide uniprot")
+        for database in (
+            *self._settings.unpaired_databases,
+            self._settings.paired_database,
+        ):
+            if database.path == Path("."):
+                raise ValueError(
+                    f"Database {database.name!r} requires an explicit path"
+                )
+            if not database.identifier.strip():
+                raise ValueError(
+                    f"Database {database.name!r} requires a non-empty identifier"
+                )
+            if database.max_sequences is not None and database.max_sequences < 1:
+                raise ValueError(
+                    f"Database {database.name!r} max_sequences must be at least 1"
+                )
+
+    def _pack(self, sequences: Sequence[str]) -> tuple[tuple[str, ...], ...]:
+        chunks: list[tuple[str, ...]] = []
+        current: list[str] = []
+        residues = 0
+        for sequence in sequences:
+            would_exceed = current and (
+                len(current) >= self._settings.max_sequences_per_batch
+                or residues + len(sequence) > self._settings.max_residues_per_batch
+            )
+            if would_exceed:
+                chunks.append(tuple(current))
+                current = []
+                residues = 0
+            current.append(sequence)
+            residues += len(sequence)
+        if current:
+            chunks.append(tuple(current))
+        return tuple(chunks)
+
+    def _search_chunk(self, sequences: Sequence[str]) -> dict[str, tuple[str, str]]:
+        with tempfile.TemporaryDirectory(
+            prefix="alphapulldown_mmseqs_", dir=self._settings.temp_dir
+        ) as temporary_directory:
+            root = Path(temporary_directory)
+            query_fasta = root / "queries.fasta"
+            query_ids = {
+                f"query_{index}": sequence
+                for index, sequence in enumerate(sequences)
+            }
+            query_fasta.write_text(
+                "".join(
+                    f">{query_id}\n{sequence}\n"
+                    for query_id, sequence in query_ids.items()
+                ),
+                encoding="utf-8",
+            )
+            query_db = root / "query_db"
+            self._mmseqs.create_query_database(query_fasta, query_db)
+
+            by_database: dict[str, dict[str, str]] = {}
+            for database in (
+                *self._settings.unpaired_databases,
+                self._settings.paired_database,
+            ):
+                database_root = root / database.name
+                database_root.mkdir()
+                result_db = database_root / "result_db"
+                work_dir = database_root / "work"
+                work_dir.mkdir()
+                msa_db = database_root / "msa_db"
+                output_dir = database_root / "a3m"
+                output_dir.mkdir()
+                self._mmseqs.search(
+                    query_db, database, result_db, work_dir, self._settings
+                )
+                self._mmseqs.result_to_msa(query_db, database, result_db, msa_db)
+                self._mmseqs.unpack_msa(query_db, msa_db, output_dir)
+                by_database[database.name] = self._read_results(
+                    query_db, output_dir, query_ids
+                )
+
+            results = {}
+            for query_id, sequence in query_ids.items():
+                unpaired = _merge_a3ms(
+                    sequence,
+                    [
+                        by_database[database.name][query_id]
+                        for database in self._settings.unpaired_databases
+                    ],
+                )
+                paired = _normalise_query(
+                    by_database[self._settings.paired_database.name][query_id], sequence
+                )
+                results[sequence] = (unpaired, paired)
+            return results
+
+    @staticmethod
+    def _read_results(
+        query_db: Path, output_dir: Path, query_ids: Mapping[str, str]
+    ) -> dict[str, str]:
+        index_to_query = {}
+        lookup_path = Path(f"{query_db}.lookup")
+        if lookup_path.exists():
+            for line in lookup_path.read_text(encoding="utf-8").splitlines():
+                fields = line.split("\t")
+                if len(fields) >= 2:
+                    index_to_query[fields[0]] = fields[1]
+        if not index_to_query:
+            index_to_query = {
+                str(index): query_id for index, query_id in enumerate(query_ids)
+            }
+
+        results = {}
+        for index, query_id in index_to_query.items():
+            if query_id not in query_ids:
+                continue
+            candidates = (
+                output_dir / f"{index}.a3m",
+                output_dir / index,
+                output_dir / f"{query_id}.a3m",
+            )
+            result_path = next((path for path in candidates if path.exists()), None)
+            if result_path is None:
+                results[query_id] = f">query\n{query_ids[query_id]}\n"
+            else:
+                results[query_id] = result_path.read_text(encoding="utf-8")
+        for query_id, sequence in query_ids.items():
+            results.setdefault(query_id, f">query\n{sequence}\n")
+        return results
+
+    def _process_with_af3(
+        self, request: FeatureRequest, unpaired_msa: str, paired_msa: str
+    ) -> dict[str, Any]:
+        from alphafold3.common import folding_input
+
+        source_payload = {
+            "name": request.name,
+            "modelSeeds": [42],
+            "sequences": [
+                {
+                    "protein": {
+                        "id": "A",
+                        "sequence": request.sequence,
+                        "description": request.name,
+                        "unpairedMsa": unpaired_msa,
+                        "pairedMsa": paired_msa,
+                        "templates": None,
+                    }
+                }
+            ],
+            "dialect": "alphafold3",
+            "version": 1,
+        }
+        fold_input = folding_input.Input.from_json(json.dumps(source_payload))
+        processed = self._af3_pipeline.process(fold_input)
+        payload = json.loads(processed.to_json())
+        payload["name"] = request.name
+        return embed_metadata_in_af3_json(payload, self._metadata())
+
+    def _metadata(self) -> dict[str, Any]:
+        metadata = copy.deepcopy(dict(self._settings.base_metadata))
+        other = metadata.setdefault("other", {})
+        other["msa_backend"] = "mmseqs2-gpu"
+        other["mmseqs2_gpu"] = self._cache_signature()
+        return metadata
+
+    def _cache_signature(self) -> dict[str, Any]:
+        def database_value(database: DatabaseSpec) -> dict[str, Any]:
+            return {
+                "name": database.name,
+                "identifier": database.identifier,
+                "max_sequences": database.max_sequences
+                or _default_max_sequences(database.name),
+            }
+
+        return {
+            "schema_version": 1,
+            "sensitivity": self._settings.sensitivity,
+            "e_value": self._settings.e_value,
+            "unpaired_databases": [
+                database_value(database)
+                for database in self._settings.unpaired_databases
+            ],
+            "paired_database": database_value(self._settings.paired_database),
+        }
+
+    def _artifact_path(self, name: str) -> Path:
+        suffix = "_af3_input.json.xz" if self._settings.compress else "_af3_input.json"
+        return self._settings.output_dir / f"{name}{suffix}"
+
+    @staticmethod
+    def _write_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+        text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+        )
+        os.close(descriptor)
+        temporary_path = Path(temporary_name)
+        try:
+            if path.suffix == ".xz":
+                with lzma.open(temporary_path, "wt", encoding="utf-8") as handle:
+                    handle.write(text)
+            else:
+                temporary_path.write_text(text, encoding="utf-8")
+            os.replace(temporary_path, path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _a3m_records(a3m: str) -> list[tuple[str, str]]:
+    records = []
+    description = None
+    sequence_parts = []
+    for line in a3m.splitlines():
+        if line.startswith(">"):
+            if description is not None:
+                records.append((description, "".join(sequence_parts)))
+            description = line[1:].strip()
+            sequence_parts = []
+        elif description is not None:
+            sequence_parts.append(line.strip())
+    if description is not None:
+        records.append((description, "".join(sequence_parts)))
+    return records
+
+
+def _normalise_query(a3m: str, query_sequence: str) -> str:
+    records = _a3m_records(a3m)
+    if not records:
+        return f">query\n{query_sequence}\n"
+    records[0] = ("query", query_sequence)
+    return "".join(f">{description}\n{sequence}\n" for description, sequence in records)
+
+
+def _merge_a3ms(query_sequence: str, a3ms: Sequence[str]) -> str:
+    rows = [("query", query_sequence)]
+    seen = {query_sequence}
+    for a3m in a3ms:
+        for _, (description, sequence) in enumerate(_a3m_records(a3m)):
+            if sequence in seen:
+                continue
+            seen.add(sequence)
+            rows.append((description, sequence))
+    return "".join(f">{description}\n{sequence}\n" for description, sequence in rows)

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -110,6 +110,11 @@ class MsaBatchSettings:
     max_residues_per_batch: int
     threads: int
     e_value: float = 1e-4
+    # MMseqs2 sizes its database splits from 90% of the PHYSICAL node memory
+    # (sysconf(_SC_PHYS_PAGES)), which ignores the cgroup a batch scheduler puts it in.
+    # On a large node with a small allocation it therefore declines to split and is
+    # OOM-killed instead. Pass the allocation explicitly, e.g. "150G".
+    split_memory_limit: str | None = None
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -138,6 +143,7 @@ class FeatureBatchSettings:
     threads: int
     msa_output_dir: Path | None = None
     e_value: float = 1e-4
+    split_memory_limit: str | None = None
     compress: bool = False
     base_metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     max_template_date: str = ""
@@ -315,6 +321,11 @@ class SubprocessMmseqsProcess:
                 str(max_sequences),
                 "--gpu",
                 "1" if self._gpu else "0",
+            )
+            + (
+                ("--split-memory-limit", settings.split_memory_limit)
+                if settings.split_memory_limit
+                else ()
             )
         )
 
@@ -920,6 +931,7 @@ class FeatureBatch:
                 max_residues_per_batch=settings.max_residues_per_batch,
                 threads=settings.threads,
                 e_value=settings.e_value,
+                split_memory_limit=settings.split_memory_limit,
             ),
             mmseqs_process=mmseqs_process,
         )

--- a/alphapulldown/scripts/_mmseqs2_cli.py
+++ b/alphapulldown/scripts/_mmseqs2_cli.py
@@ -77,6 +77,13 @@ def define_msa_search_flags(
         "MMseqs2 search E-value cutoff.",
     )
     _define_once(
+        "mmseqs_use_gpu",
+        flags.DEFINE_bool,
+        True,
+        "Run the MMseqs2 search on a GPU (requires GPU-padded databases and a GPU "
+        "allocation). Set false to search on CPU instead.",
+    )
+    _define_once(
         "mmseqs_threads",
         flags.DEFINE_integer,
         8,

--- a/alphapulldown/scripts/_mmseqs2_cli.py
+++ b/alphapulldown/scripts/_mmseqs2_cli.py
@@ -7,16 +7,14 @@ from typing import Callable
 
 from absl import flags
 
-from alphapulldown.feature_batch import DatabaseSpec
-
-
-DATABASE_NAMES = ("uniref90", "mgnify", "small_bfd", "uniprot")
-DEFAULT_MAX_SEQUENCES = {
-    "uniref90": 10_000,
-    "mgnify": 5_000,
-    "small_bfd": 5_000,
-    "uniprot": 50_000,
-}
+from alphapulldown.feature_batch import (
+    DATABASE_NAMES,
+    DEFAULT_MAX_SEQUENCES,
+    PAIRED_DATABASE_NAME,
+    UNPAIRED_DATABASE_NAMES,
+    DatabaseSelection,
+    DatabaseSpec,
+)
 
 
 def _define_once(name: str, define: Callable, default, help_text: str) -> None:
@@ -126,6 +124,16 @@ def database_spec(flag_values: flags.FlagValues, name: str) -> DatabaseSpec:
         path=Path(flag_values[f"mmseqs_{name}_database_path"].value),
         identifier=flag_values[f"mmseqs_{name}_database_id"].value,
         max_sequences=flag_values[f"mmseqs_{name}_max_sequences"].value,
+    )
+
+
+def database_selection(flag_values: flags.FlagValues) -> DatabaseSelection:
+    """Configured databases with their roles named, rather than sliced by position."""
+    return DatabaseSelection(
+        unpaired=tuple(
+            database_spec(flag_values, name) for name in UNPAIRED_DATABASE_NAMES
+        ),
+        paired=database_spec(flag_values, PAIRED_DATABASE_NAME),
     )
 
 

--- a/alphapulldown/scripts/_mmseqs2_cli.py
+++ b/alphapulldown/scripts/_mmseqs2_cli.py
@@ -1,0 +1,148 @@
+"""Shared lightweight flag schema for local MMseqs2 feature entry points."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from absl import flags
+
+from alphapulldown.feature_batch import DatabaseSpec
+
+
+DATABASE_NAMES = ("uniref90", "mgnify", "small_bfd", "uniprot")
+DEFAULT_MAX_SEQUENCES = {
+    "uniref90": 10_000,
+    "mgnify": 5_000,
+    "small_bfd": 5_000,
+    "uniprot": 50_000,
+}
+
+
+def _define_once(name: str, define: Callable, default, help_text: str) -> None:
+    if name not in flags.FLAGS:
+        define(name, default, help_text)
+
+
+def define_msa_search_flags(
+    *, include_fasta_paths: bool = False, include_summary_path: bool = False
+) -> None:
+    """Register the shared MSA-stage flags without duplicating global names."""
+    if include_fasta_paths:
+        _define_once(
+            "fasta_paths",
+            flags.DEFINE_list,
+            None,
+            "Paths to protein FASTA files.",
+        )
+    _define_once(
+        "msa_output_dir",
+        flags.DEFINE_string,
+        None,
+        "Durable per-protein MSA bundle directory.",
+    )
+    if include_summary_path:
+        _define_once(
+            "summary_path",
+            flags.DEFINE_string,
+            None,
+            "Atomic whole-shard completion record.",
+        )
+    _define_once(
+        "mmseqs_binary_path",
+        flags.DEFINE_string,
+        "/opt/mmseqs/bin/mmseqs",
+        "Path to the bundled GPU-capable MMseqs2 executable.",
+    )
+    _define_once(
+        "mmseqs_temp_dir",
+        flags.DEFINE_string,
+        None,
+        "Fast local MMseqs2 scratch directory.",
+    )
+    _define_once(
+        "mmseqs_batch_max_sequences",
+        flags.DEFINE_integer,
+        None,
+        "Maximum unique sequences per query database.",
+    )
+    _define_once(
+        "mmseqs_batch_max_residues",
+        flags.DEFINE_integer,
+        None,
+        "Maximum residues per query database.",
+    )
+    _define_once(
+        "mmseqs_e_value",
+        flags.DEFINE_float,
+        1e-4,
+        "MMseqs2 search E-value cutoff.",
+    )
+    _define_once(
+        "mmseqs_threads",
+        flags.DEFINE_integer,
+        8,
+        "CPU threads for MMseqs2 operations.",
+    )
+    for database_name in DATABASE_NAMES:
+        _define_once(
+            f"mmseqs_{database_name}_database_path",
+            flags.DEFINE_string,
+            None,
+            f"Explicit GPU-compatible MMseqs2 {database_name} database prefix.",
+        )
+        _define_once(
+            f"mmseqs_{database_name}_database_id",
+            flags.DEFINE_string,
+            None,
+            f"Immutable identifier for the {database_name} database build.",
+        )
+        _define_once(
+            f"mmseqs_{database_name}_max_sequences",
+            flags.DEFINE_integer,
+            DEFAULT_MAX_SEQUENCES[database_name],
+            f"Maximum {database_name} hits per query.",
+        )
+
+
+def define_template_provenance_flags() -> None:
+    _define_once(
+        "template_seqres_database_id",
+        flags.DEFINE_string,
+        None,
+        "Immutable identity of the PDB seqres database used for templates.",
+    )
+    _define_once(
+        "template_mmcif_database_id",
+        flags.DEFINE_string,
+        None,
+        "Immutable identity of the mmCIF directory used for templates.",
+    )
+
+
+def database_spec(flag_values: flags.FlagValues, name: str) -> DatabaseSpec:
+    return DatabaseSpec(
+        name=name,
+        path=Path(flag_values[f"mmseqs_{name}_database_path"].value),
+        identifier=flag_values[f"mmseqs_{name}_database_id"].value,
+        max_sequences=flag_values[f"mmseqs_{name}_max_sequences"].value,
+    )
+
+
+def required_msa_flag_names() -> tuple[str, ...]:
+    return (
+        "msa_output_dir",
+        "mmseqs_binary_path",
+        "mmseqs_temp_dir",
+        "mmseqs_batch_max_sequences",
+        "mmseqs_batch_max_residues",
+        *(
+            f"mmseqs_{database_name}_{suffix}"
+            for database_name in DATABASE_NAMES
+            for suffix in ("database_path", "database_id")
+        ),
+    )
+
+
+def required_template_flag_names() -> tuple[str, ...]:
+    return ("template_seqres_database_id", "template_mmcif_database_id")

--- a/alphapulldown/scripts/_mmseqs2_cli.py
+++ b/alphapulldown/scripts/_mmseqs2_cli.py
@@ -77,6 +77,14 @@ def define_msa_search_flags(
         "MMseqs2 search E-value cutoff.",
     )
     _define_once(
+        "mmseqs_split_memory_limit",
+        flags.DEFINE_string,
+        None,
+        "Memory MMseqs2 may use before splitting the target database, e.g. '150G'. "
+        "Leave unset and MMseqs2 assumes 90% of the physical node memory, which "
+        "ignores any cgroup limit a batch scheduler applied.",
+    )
+    _define_once(
         "mmseqs_use_gpu",
         flags.DEFINE_bool,
         True,

--- a/alphapulldown/scripts/compare_msa_backends.py
+++ b/alphapulldown/scripts/compare_msa_backends.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Compare MSA depth/template counts without claiming prediction equivalence."""
+
+from __future__ import annotations
+
+import json
+import lzma
+from pathlib import Path
+
+from absl import app, flags
+
+from alphapulldown.utils.msa_quality import measure_a3m
+
+
+flags.DEFINE_string(
+    "reference_dir", None, "Directory of native/jackhmmer AF3 JSON artifacts."
+)
+flags.DEFINE_string("candidate_dir", None, "Directory of MMseqs2 AF3 JSON artifacts.")
+flags.DEFINE_string("output_path", None, "JSON report path.")
+FLAGS = flags.FLAGS
+
+
+def _read(path: Path) -> dict:
+    opener = lzma.open if path.suffix == ".xz" else open
+    with opener(path, "rt", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _artifacts(directory: Path) -> dict[str, Path]:
+    result = {}
+    for path in sorted(directory.glob("*_af3_input.json*")):
+        filename = path.name
+        if filename.endswith(".xz"):
+            filename = filename[: -len(".xz")]
+        name = filename[: -len("_af3_input.json")]
+        result[name] = path
+    return result
+
+
+def compare_directories(reference_dir: Path, candidate_dir: Path) -> list[dict]:
+    """Return paired, machine-readable inputs for the scientific merge gate."""
+    references = _artifacts(reference_dir)
+    candidates = _artifacts(candidate_dir)
+    missing_candidates = sorted(references.keys() - candidates.keys())
+    missing_references = sorted(candidates.keys() - references.keys())
+    if missing_candidates or missing_references:
+        details = []
+        if missing_candidates:
+            details.append("missing from candidate: " + ", ".join(missing_candidates))
+        if missing_references:
+            details.append("missing from reference: " + ", ".join(missing_references))
+        raise ValueError("Artifact sets differ; " + "; ".join(details))
+    rows = []
+    for name in sorted(references):
+        reference = _read(references[name])
+        candidate = _read(candidates[name])
+        reference_protein = reference["sequences"][0]["protein"]
+        candidate_protein = candidate["sequences"][0]["protein"]
+        if reference_protein["sequence"] != candidate_protein["sequence"]:
+            raise ValueError(f"Sequence mismatch for {name!r}")
+        length = len(reference_protein["sequence"])
+        rows.append(
+            {
+                "name": name,
+                "reference_path": str(references[name]),
+                "candidate_path": str(candidates[name]),
+                "reference_unpaired": measure_a3m(
+                    reference_protein["unpairedMsa"], query_length=length
+                ),
+                "candidate_unpaired": measure_a3m(
+                    candidate_protein["unpairedMsa"], query_length=length
+                ),
+                "reference_paired": measure_a3m(
+                    reference_protein["pairedMsa"], query_length=length
+                ),
+                "candidate_paired": measure_a3m(
+                    candidate_protein["pairedMsa"], query_length=length
+                ),
+                "reference_template_count": len(
+                    reference_protein.get("templates") or []
+                ),
+                "candidate_template_count": len(
+                    candidate_protein.get("templates") or []
+                ),
+            }
+        )
+    return rows
+
+
+def summarize(rows: list[dict]) -> dict:
+    """Aggregate paired counts while retaining zero-depth cases explicitly."""
+    if not rows:
+        return {"protein_count": 0}
+
+    def mean(key: str, backend: str) -> float:
+        return sum(row[f"{backend}_{key}"]["depth"] for row in rows) / len(rows)
+
+    return {
+        "protein_count": len(rows),
+        "mean_reference_unpaired_depth": mean("unpaired", "reference"),
+        "mean_candidate_unpaired_depth": mean("unpaired", "candidate"),
+        "mean_reference_paired_depth": mean("paired", "reference"),
+        "mean_candidate_paired_depth": mean("paired", "candidate"),
+        "total_reference_templates": sum(
+            row["reference_template_count"] for row in rows
+        ),
+        "total_candidate_templates": sum(
+            row["candidate_template_count"] for row in rows
+        ),
+    }
+
+
+def main(argv) -> None:
+    del argv
+    proteins = compare_directories(Path(FLAGS.reference_dir), Path(FLAGS.candidate_dir))
+    report = {
+        "schemaVersion": 1,
+        "warning": (
+            "MSA/template metrics are diagnostic only; run matched inference and "
+            "DockQ against experimental references before claiming accuracy equivalence."
+        ),
+        "summary": summarize(proteins),
+        "proteins": proteins,
+    }
+    Path(FLAGS.output_path).write_text(
+        json.dumps(report, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    flags.mark_flags_as_required(["reference_dir", "candidate_dir", "output_path"])
+    app.run(main)

--- a/alphapulldown/scripts/create_batch_features.py
+++ b/alphapulldown/scripts/create_batch_features.py
@@ -3,8 +3,14 @@
 
 from __future__ import annotations
 
+import os
+
+# AF3's data pipeline imports JAX even though feature generation does not use its
+# accelerator backend.  Reserve the GPU for the external MMseqs2 process without
+# changing CUDA visibility for that process.
+os.environ["JAX_PLATFORMS"] = "cpu"
+
 from pathlib import Path
-import shutil
 from typing import Sequence
 
 from absl import app, flags, logging
@@ -21,7 +27,9 @@ from alphapulldown.utils.file_handling import iter_seqs
 
 
 flags.DEFINE_string(
-    "mmseqs_binary_path", shutil.which("mmseqs"), "Path to the MMseqs2 executable."
+    "mmseqs_binary_path",
+    "/opt/mmseqs/bin/mmseqs",
+    "Path to a GPU-capable MMseqs2 executable.",
 )
 flags.DEFINE_string(
     "mmseqs_temp_dir", None, "Fast local directory for temporary MMseqs2 files."

--- a/alphapulldown/scripts/create_batch_features.py
+++ b/alphapulldown/scripts/create_batch_features.py
@@ -14,7 +14,6 @@ from typing import Sequence
 from absl import app, flags, logging
 
 from alphapulldown.feature_batch import (
-    DatabaseSpec,
     FeatureBatch,
     FeatureBatchSettings,
     FeatureRequest,
@@ -22,65 +21,20 @@ from alphapulldown.feature_batch import (
     protein_requests_from_fastas,
 )
 from alphapulldown.scripts import create_individual_features as legacy_features
-
-
-flags.DEFINE_string(
-    "mmseqs_binary_path",
-    "/opt/mmseqs/bin/mmseqs",
-    "Path to the bundled GPU-capable MMseqs2 executable.",
-)
-flags.DEFINE_string("mmseqs_temp_dir", None, "Fast local MMseqs2 scratch directory.")
-flags.DEFINE_string("msa_output_dir", None, "Durable per-protein MSA bundle directory.")
-flags.DEFINE_integer(
-    "mmseqs_batch_max_sequences", None, "Maximum unique sequences per query database."
-)
-flags.DEFINE_integer(
-    "mmseqs_batch_max_residues", None, "Maximum residues per query database."
-)
-flags.DEFINE_float("mmseqs_e_value", 1e-4, "MMseqs2 search E-value cutoff.")
-flags.DEFINE_integer("mmseqs_threads", 8, "CPU threads for MMseqs2 operations.")
-flags.DEFINE_string(
-    "template_seqres_database_id", None, "Immutable PDB seqres database identity."
-)
-flags.DEFINE_string(
-    "template_mmcif_database_id", None, "Immutable mmCIF directory identity."
+from alphapulldown.scripts._mmseqs2_cli import (
+    DATABASE_NAMES,
+    database_spec,
+    define_msa_search_flags,
+    define_template_provenance_flags,
+    required_msa_flag_names,
+    required_template_flag_names,
 )
 
-for database_name in ("uniref90", "mgnify", "small_bfd", "uniprot"):
-    flags.DEFINE_string(
-        f"mmseqs_{database_name}_database_path",
-        None,
-        f"Explicit GPU-compatible MMseqs2 {database_name} database prefix.",
-    )
-    flags.DEFINE_string(
-        f"mmseqs_{database_name}_database_id",
-        None,
-        f"Immutable identifier for the {database_name} database build.",
-    )
 
-flags.DEFINE_integer(
-    "mmseqs_uniref90_max_sequences", 10_000, "Maximum UniRef90 hits per query."
-)
-flags.DEFINE_integer(
-    "mmseqs_mgnify_max_sequences", 5_000, "Maximum MGnify hits per query."
-)
-flags.DEFINE_integer(
-    "mmseqs_small_bfd_max_sequences", 5_000, "Maximum small-BFD hits per query."
-)
-flags.DEFINE_integer(
-    "mmseqs_uniprot_max_sequences", 50_000, "Maximum paired UniProt hits per query."
-)
+define_msa_search_flags()
+define_template_provenance_flags()
 
 FLAGS = flags.FLAGS
-
-
-def _database(name: str) -> DatabaseSpec:
-    return DatabaseSpec(
-        name=name,
-        path=Path(getattr(FLAGS, f"mmseqs_{name}_database_path")),
-        identifier=getattr(FLAGS, f"mmseqs_{name}_database_id"),
-        max_sequences=getattr(FLAGS, f"mmseqs_{name}_max_sequences"),
-    )
 
 
 def _feature_requests(fasta_paths: Sequence[str]) -> tuple[FeatureRequest, ...]:
@@ -109,9 +63,9 @@ def main(argv) -> None:
             msa_output_dir=Path(FLAGS.msa_output_dir),
             temp_dir=Path(FLAGS.mmseqs_temp_dir),
             unpaired_databases=tuple(
-                _database(name) for name in ("uniref90", "mgnify", "small_bfd")
+                database_spec(FLAGS, name) for name in DATABASE_NAMES[:3]
             ),
-            paired_database=_database("uniprot"),
+            paired_database=database_spec(FLAGS, "uniprot"),
             max_sequences_per_batch=FLAGS.mmseqs_batch_max_sequences,
             max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
             threads=FLAGS.mmseqs_threads,
@@ -144,19 +98,9 @@ if __name__ == "__main__":
             "fasta_paths",
             "data_dir",
             "output_dir",
-            "msa_output_dir",
             "max_template_date",
-            "template_seqres_database_id",
-            "template_mmcif_database_id",
-            "mmseqs_binary_path",
-            "mmseqs_temp_dir",
-            "mmseqs_batch_max_sequences",
-            "mmseqs_batch_max_residues",
-            *[
-                f"mmseqs_{database_name}_{suffix}"
-                for database_name in ("uniref90", "mgnify", "small_bfd", "uniprot")
-                for suffix in ("database_path", "database_id")
-            ],
+            *required_template_flag_names(),
+            *required_msa_flag_names(),
         ]
     )
     app.run(main)

--- a/alphapulldown/scripts/create_batch_features.py
+++ b/alphapulldown/scripts/create_batch_features.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Thin command-line adapter for batched local MMseqs2-GPU AF3 features."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+from typing import Sequence
+
+from absl import app, flags, logging
+
+from alphapulldown.feature_batch import (
+    DatabaseSpec,
+    FeatureBatch,
+    FeatureBatchSettings,
+    FeatureRequest,
+    SubprocessMmseqsProcess,
+)
+from alphapulldown.scripts import create_individual_features as legacy_features
+from alphapulldown.utils.file_handling import iter_seqs
+
+
+flags.DEFINE_string(
+    "mmseqs_binary_path", shutil.which("mmseqs"), "Path to the MMseqs2 executable."
+)
+flags.DEFINE_string(
+    "mmseqs_temp_dir", None, "Fast local directory for temporary MMseqs2 files."
+)
+flags.DEFINE_integer(
+    "mmseqs_batch_max_sequences",
+    None,
+    "Maximum unique protein sequences in one MMseqs2 query database.",
+)
+flags.DEFINE_integer(
+    "mmseqs_batch_max_residues",
+    None,
+    "Maximum total residues in one MMseqs2 query database.",
+)
+flags.DEFINE_float("mmseqs_sensitivity", 7.5, "MMseqs2 search sensitivity.")
+flags.DEFINE_float("mmseqs_e_value", 1e-4, "MMseqs2 search E-value cutoff.")
+flags.DEFINE_integer("mmseqs_threads", 8, "CPU threads for MMseqs2 operations.")
+
+for database_name in ("uniref90", "mgnify", "small_bfd", "uniprot"):
+    flags.DEFINE_string(
+        f"mmseqs_{database_name}_database_path",
+        None,
+        f"Explicit local MMseqs2 {database_name} database prefix.",
+    )
+    flags.DEFINE_string(
+        f"mmseqs_{database_name}_database_id",
+        None,
+        f"Immutable identifier for the configured {database_name} database build.",
+    )
+
+flags.DEFINE_integer(
+    "mmseqs_uniref90_max_sequences", 10_000, "Maximum UniRef90 hits per query."
+)
+flags.DEFINE_integer(
+    "mmseqs_mgnify_max_sequences", 5_000, "Maximum MGnify hits per query."
+)
+flags.DEFINE_integer(
+    "mmseqs_small_bfd_max_sequences", 5_000, "Maximum small-BFD hits per query."
+)
+flags.DEFINE_integer(
+    "mmseqs_uniprot_max_sequences", 50_000, "Maximum paired UniProt hits per query."
+)
+
+FLAGS = flags.FLAGS
+
+
+def _database(name: str) -> DatabaseSpec:
+    return DatabaseSpec(
+        name=name,
+        path=Path(getattr(FLAGS, f"mmseqs_{name}_database_path")),
+        identifier=getattr(FLAGS, f"mmseqs_{name}_database_id"),
+        max_sequences=getattr(FLAGS, f"mmseqs_{name}_max_sequences"),
+    )
+
+
+def _feature_requests(fasta_paths: Sequence[str]) -> tuple[FeatureRequest, ...]:
+    requests = []
+    for sequence, description in iter_seqs(fasta_paths):
+        chain_kind = legacy_features.get_af3_chain_kind(description, sequence)
+        if chain_kind != "protein":
+            raise ValueError(
+                "Batched local MMseqs2-GPU features accept proteins only; "
+                f"{description!r} is {chain_kind}"
+            )
+        requests.append(FeatureRequest(name=description, sequence=sequence))
+    return tuple(requests)
+
+
+def main(argv):
+    del argv
+    if FLAGS.data_pipeline != "alphafold3":
+        raise ValueError(
+            "Batched local MMseqs2-GPU features require "
+            "--data_pipeline=alphafold3"
+        )
+    if FLAGS.use_mmseqs2:
+        raise ValueError(
+            "--use_mmseqs2 selects the existing remote AF2 path and cannot be combined "
+            "with batched local MMseqs2-GPU generation"
+        )
+    if FLAGS.keep_msas or FLAGS.skip_msa or FLAGS.path_to_mmt:
+        raise ValueError(
+            "Batched local MMseqs2-GPU generation does not support --keep_msas, "
+            "--skip_msa, or --path_to_mmt"
+        )
+
+    legacy_features.create_arguments()
+    native_pipeline = legacy_features.create_pipeline_af3()
+    metadata = legacy_features.get_af3_feature_metadata(
+        {"protein"}, skip_msa=True
+    )
+    requests = _feature_requests(FLAGS.fasta_paths)
+    settings = FeatureBatchSettings(
+        output_dir=Path(FLAGS.output_dir),
+        temp_dir=Path(FLAGS.mmseqs_temp_dir),
+        unpaired_databases=(
+            _database("uniref90"),
+            _database("mgnify"),
+            _database("small_bfd"),
+        ),
+        paired_database=_database("uniprot"),
+        max_sequences_per_batch=FLAGS.mmseqs_batch_max_sequences,
+        max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
+        threads=FLAGS.mmseqs_threads,
+        sensitivity=FLAGS.mmseqs_sensitivity,
+        e_value=FLAGS.mmseqs_e_value,
+        compress=FLAGS.compress_features,
+        base_metadata=metadata,
+    )
+    result = FeatureBatch(
+        settings=settings,
+        mmseqs_process=SubprocessMmseqsProcess(FLAGS.mmseqs_binary_path),
+        af3_pipeline=native_pipeline,
+    ).generate(requests)
+
+    logging.info(
+        "Batched local MMseqs2-GPU features: %d written, %d reused, %d failed",
+        len(result.written),
+        len(result.reused),
+        len(result.failures),
+    )
+    if result.failures:
+        summary = ", ".join(
+            f"{failure.name} ({failure.error})" for failure in result.failures
+        )
+        raise RuntimeError(
+            f"Failed to create {len(result.failures)} AF3 feature artifact(s): "
+            f"{summary}"
+        )
+
+
+if __name__ == "__main__":
+    flags.mark_flags_as_required(
+        [
+            "fasta_paths",
+            "data_dir",
+            "output_dir",
+            "max_template_date",
+            "mmseqs_binary_path",
+            "mmseqs_temp_dir",
+            "mmseqs_batch_max_sequences",
+            "mmseqs_batch_max_residues",
+            *[
+                f"mmseqs_{database_name}_{suffix}"
+                for database_name in ("uniref90", "mgnify", "small_bfd", "uniprot")
+                for suffix in ("database_path", "database_id")
+            ],
+        ]
+    )
+    app.run(main)

--- a/alphapulldown/scripts/create_batch_features.py
+++ b/alphapulldown/scripts/create_batch_features.py
@@ -74,7 +74,9 @@ def main(argv) -> None:
             template_seqres_database_id=FLAGS.template_seqres_database_id,
             template_mmcif_database_id=FLAGS.template_mmcif_database_id,
         ),
-        mmseqs_process=SubprocessMmseqsProcess(FLAGS.mmseqs_binary_path),
+        mmseqs_process=SubprocessMmseqsProcess(
+            FLAGS.mmseqs_binary_path, gpu=FLAGS.mmseqs_use_gpu
+        ),
         af3_pipeline=pipeline,
     ).generate(requests)
     logging.info(

--- a/alphapulldown/scripts/create_batch_features.py
+++ b/alphapulldown/scripts/create_batch_features.py
@@ -85,6 +85,13 @@ def main(argv) -> None:
         len(result.reused),
         len(result.failures),
     )
+    produced = len(result.written) + len(result.reused)
+    if produced and len(result.query_only) == produced:
+        raise RuntimeError(
+            "Every MSA in this batch contains only the query sequence; check that the "
+            f"configured MMseqs2 databases exist and are searchable "
+            f"({', '.join(result.query_only)})"
+        )
     if result.failures:
         detail = ", ".join(f"{item.name} ({item.error})" for item in result.failures)
         raise RuntimeError(

--- a/alphapulldown/scripts/create_batch_features.py
+++ b/alphapulldown/scripts/create_batch_features.py
@@ -68,6 +68,7 @@ def main(argv) -> None:
             max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
             threads=FLAGS.mmseqs_threads,
             e_value=FLAGS.mmseqs_e_value,
+        split_memory_limit=FLAGS.mmseqs_split_memory_limit,
             compress=FLAGS.compress_features,
             base_metadata=metadata,
             max_template_date=FLAGS.max_template_date,

--- a/alphapulldown/scripts/create_batch_features.py
+++ b/alphapulldown/scripts/create_batch_features.py
@@ -22,8 +22,7 @@ from alphapulldown.feature_batch import (
 )
 from alphapulldown.scripts import create_individual_features as legacy_features
 from alphapulldown.scripts._mmseqs2_cli import (
-    DATABASE_NAMES,
-    database_spec,
+    database_selection,
     define_msa_search_flags,
     define_template_provenance_flags,
     required_msa_flag_names,
@@ -57,15 +56,14 @@ def main(argv) -> None:
     pipeline = legacy_features.create_pipeline_af3()
     metadata = legacy_features.get_af3_feature_metadata({"protein"}, skip_msa=True)
     requests = _feature_requests(FLAGS.fasta_paths)
+    databases = database_selection(FLAGS)
     result = FeatureBatch(
         settings=FeatureBatchSettings(
             output_dir=Path(FLAGS.output_dir),
             msa_output_dir=Path(FLAGS.msa_output_dir),
             temp_dir=Path(FLAGS.mmseqs_temp_dir),
-            unpaired_databases=tuple(
-                database_spec(FLAGS, name) for name in DATABASE_NAMES[:3]
-            ),
-            paired_database=database_spec(FLAGS, "uniprot"),
+            unpaired_databases=databases.unpaired,
+            paired_database=databases.paired,
             max_sequences_per_batch=FLAGS.mmseqs_batch_max_sequences,
             max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
             threads=FLAGS.mmseqs_threads,

--- a/alphapulldown/scripts/create_batch_msas.py
+++ b/alphapulldown/scripts/create_batch_msas.py
@@ -49,11 +49,19 @@ def main(argv) -> None:
         mmseqs_process=SubprocessMmseqsProcess(FLAGS.mmseqs_binary_path),
     ).generate(requests)
     logging.info(
-        "MMseqs2-GPU MSA stage: %d written, %d reused, %d failed",
+        "MMseqs2-GPU MSA stage: %d written, %d reused, %d failed, %d query-only",
         len(result.written),
         len(result.reused),
         len(result.failures),
+        len(result.query_only),
     )
+    produced = len(result.written) + len(result.reused)
+    if produced and len(result.query_only) == produced:
+        raise RuntimeError(
+            "Every MSA in this shard contains only the query sequence. A whole shard of "
+            "orphan proteins is not plausible; check that the configured MMseqs2 "
+            f"databases exist and are searchable ({', '.join(result.query_only)})"
+        )
     if result.failures:
         detail = ", ".join(
             f"{failure.name} ({failure.error})" for failure in result.failures

--- a/alphapulldown/scripts/create_batch_msas.py
+++ b/alphapulldown/scripts/create_batch_msas.py
@@ -1,36 +1,31 @@
 #!/usr/bin/env python3
-"""Compatibility CLI composing MMseqs2-GPU MSA and AF3 finalization stages."""
+"""GPU-only MMseqs2 MSA stage; intentionally imports neither AlphaFold nor JAX."""
 
 from __future__ import annotations
 
-import os
-
-# The composed direct mode imports AF3. Prevent JAX from reserving MMseqs' GPU.
-os.environ["JAX_PLATFORMS"] = "cpu"
-
 from pathlib import Path
-from typing import Sequence
 
 from absl import app, flags, logging
 
 from alphapulldown.feature_batch import (
     DatabaseSpec,
-    FeatureBatch,
-    FeatureBatchSettings,
-    FeatureRequest,
+    MsaBatch,
+    MsaBatchSettings,
     SubprocessMmseqsProcess,
     protein_requests_from_fastas,
+    write_batch_summary,
 )
-from alphapulldown.scripts import create_individual_features as legacy_features
 
 
+flags.DEFINE_list("fasta_paths", None, "Paths to protein FASTA files.")
+flags.DEFINE_string("msa_output_dir", None, "Durable per-protein MSA bundle directory.")
+flags.DEFINE_string("summary_path", None, "Atomic whole-shard completion record.")
 flags.DEFINE_string(
     "mmseqs_binary_path",
     "/opt/mmseqs/bin/mmseqs",
     "Path to the bundled GPU-capable MMseqs2 executable.",
 )
 flags.DEFINE_string("mmseqs_temp_dir", None, "Fast local MMseqs2 scratch directory.")
-flags.DEFINE_string("msa_output_dir", None, "Durable per-protein MSA bundle directory.")
 flags.DEFINE_integer(
     "mmseqs_batch_max_sequences", None, "Maximum unique sequences per query database."
 )
@@ -39,12 +34,6 @@ flags.DEFINE_integer(
 )
 flags.DEFINE_float("mmseqs_e_value", 1e-4, "MMseqs2 search E-value cutoff.")
 flags.DEFINE_integer("mmseqs_threads", 8, "CPU threads for MMseqs2 operations.")
-flags.DEFINE_string(
-    "template_seqres_database_id", None, "Immutable PDB seqres database identity."
-)
-flags.DEFINE_string(
-    "template_mmcif_database_id", None, "Immutable mmCIF directory identity."
-)
 
 for database_name in ("uniref90", "mgnify", "small_bfd", "uniprot"):
     flags.DEFINE_string(
@@ -83,71 +72,49 @@ def _database(name: str) -> DatabaseSpec:
     )
 
 
-def _feature_requests(fasta_paths: Sequence[str]) -> tuple[FeatureRequest, ...]:
-    return protein_requests_from_fastas(fasta_paths)
-
-
 def main(argv) -> None:
     del argv
-    if FLAGS.data_pipeline != "alphafold3":
-        raise ValueError(
-            "Batched local MMseqs2-GPU features require --data_pipeline=alphafold3"
-        )
-    if FLAGS.use_mmseqs2 or FLAGS.keep_msas or FLAGS.skip_msa or FLAGS.path_to_mmt:
-        raise ValueError(
-            "Batched local MMseqs2-GPU generation cannot be combined with "
-            "--use_mmseqs2, --keep_msas, --skip_msa, or --path_to_mmt"
-        )
-
-    legacy_features.create_arguments()
-    pipeline = legacy_features.create_pipeline_af3()
-    metadata = legacy_features.get_af3_feature_metadata({"protein"}, skip_msa=True)
-    requests = _feature_requests(FLAGS.fasta_paths)
-    result = FeatureBatch(
-        settings=FeatureBatchSettings(
-            output_dir=Path(FLAGS.output_dir),
-            msa_output_dir=Path(FLAGS.msa_output_dir),
-            temp_dir=Path(FLAGS.mmseqs_temp_dir),
-            unpaired_databases=tuple(
-                _database(name) for name in ("uniref90", "mgnify", "small_bfd")
-            ),
-            paired_database=_database("uniprot"),
-            max_sequences_per_batch=FLAGS.mmseqs_batch_max_sequences,
-            max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
-            threads=FLAGS.mmseqs_threads,
-            e_value=FLAGS.mmseqs_e_value,
-            compress=FLAGS.compress_features,
-            base_metadata=metadata,
-            max_template_date=FLAGS.max_template_date,
-            template_seqres_database_id=FLAGS.template_seqres_database_id,
-            template_mmcif_database_id=FLAGS.template_mmcif_database_id,
+    summary_path = Path(FLAGS.summary_path)
+    summary_path.unlink(missing_ok=True)
+    requests = protein_requests_from_fastas(FLAGS.fasta_paths)
+    settings = MsaBatchSettings(
+        output_dir=Path(FLAGS.msa_output_dir),
+        temp_dir=Path(FLAGS.mmseqs_temp_dir),
+        unpaired_databases=tuple(
+            _database(name) for name in ("uniref90", "mgnify", "small_bfd")
         ),
+        paired_database=_database("uniprot"),
+        max_sequences_per_batch=FLAGS.mmseqs_batch_max_sequences,
+        max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
+        threads=FLAGS.mmseqs_threads,
+        e_value=FLAGS.mmseqs_e_value,
+    )
+    result = MsaBatch(
+        settings=settings,
         mmseqs_process=SubprocessMmseqsProcess(FLAGS.mmseqs_binary_path),
-        af3_pipeline=pipeline,
     ).generate(requests)
     logging.info(
-        "Batched local MMseqs2-GPU features: %d written, %d reused, %d failed",
+        "MMseqs2-GPU MSA stage: %d written, %d reused, %d failed",
         len(result.written),
         len(result.reused),
         len(result.failures),
     )
     if result.failures:
-        detail = ", ".join(f"{item.name} ({item.error})" for item in result.failures)
-        raise RuntimeError(
-            f"Failed to create {len(result.failures)} artifact(s): {detail}"
+        detail = ", ".join(
+            f"{failure.name} ({failure.error})" for failure in result.failures
         )
+        raise RuntimeError(
+            f"MMseqs2-GPU MSA stage failed for {len(result.failures)} protein(s): {detail}"
+        )
+    write_batch_summary(summary_path, result)
 
 
 if __name__ == "__main__":
     flags.mark_flags_as_required(
         [
             "fasta_paths",
-            "data_dir",
-            "output_dir",
             "msa_output_dir",
-            "max_template_date",
-            "template_seqres_database_id",
-            "template_mmcif_database_id",
+            "summary_path",
             "mmseqs_binary_path",
             "mmseqs_temp_dir",
             "mmseqs_batch_max_sequences",

--- a/alphapulldown/scripts/create_batch_msas.py
+++ b/alphapulldown/scripts/create_batch_msas.py
@@ -15,8 +15,7 @@ from alphapulldown.feature_batch import (
     write_batch_summary,
 )
 from alphapulldown.scripts._mmseqs2_cli import (
-    DATABASE_NAMES,
-    database_spec,
+    database_selection,
     define_msa_search_flags,
     required_msa_flag_names,
 )
@@ -32,13 +31,12 @@ def main(argv) -> None:
     summary_path = Path(FLAGS.summary_path)
     summary_path.unlink(missing_ok=True)
     requests = protein_requests_from_fastas(FLAGS.fasta_paths)
+    databases = database_selection(FLAGS)
     settings = MsaBatchSettings(
         output_dir=Path(FLAGS.msa_output_dir),
         temp_dir=Path(FLAGS.mmseqs_temp_dir),
-        unpaired_databases=tuple(
-            database_spec(FLAGS, name) for name in DATABASE_NAMES[:3]
-        ),
-        paired_database=database_spec(FLAGS, "uniprot"),
+        unpaired_databases=databases.unpaired,
+        paired_database=databases.paired,
         max_sequences_per_batch=FLAGS.mmseqs_batch_max_sequences,
         max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
         threads=FLAGS.mmseqs_threads,

--- a/alphapulldown/scripts/create_batch_msas.py
+++ b/alphapulldown/scripts/create_batch_msas.py
@@ -44,7 +44,9 @@ def main(argv) -> None:
     )
     result = MsaBatch(
         settings=settings,
-        mmseqs_process=SubprocessMmseqsProcess(FLAGS.mmseqs_binary_path),
+        mmseqs_process=SubprocessMmseqsProcess(
+            FLAGS.mmseqs_binary_path, gpu=FLAGS.mmseqs_use_gpu
+        ),
     ).generate(requests)
     logging.info(
         "MMseqs2-GPU MSA stage: %d written, %d reused, %d failed, %d query-only",

--- a/alphapulldown/scripts/create_batch_msas.py
+++ b/alphapulldown/scripts/create_batch_msas.py
@@ -8,68 +8,23 @@ from pathlib import Path
 from absl import app, flags, logging
 
 from alphapulldown.feature_batch import (
-    DatabaseSpec,
     MsaBatch,
     MsaBatchSettings,
     SubprocessMmseqsProcess,
     protein_requests_from_fastas,
     write_batch_summary,
 )
+from alphapulldown.scripts._mmseqs2_cli import (
+    DATABASE_NAMES,
+    database_spec,
+    define_msa_search_flags,
+    required_msa_flag_names,
+)
 
 
-flags.DEFINE_list("fasta_paths", None, "Paths to protein FASTA files.")
-flags.DEFINE_string("msa_output_dir", None, "Durable per-protein MSA bundle directory.")
-flags.DEFINE_string("summary_path", None, "Atomic whole-shard completion record.")
-flags.DEFINE_string(
-    "mmseqs_binary_path",
-    "/opt/mmseqs/bin/mmseqs",
-    "Path to the bundled GPU-capable MMseqs2 executable.",
-)
-flags.DEFINE_string("mmseqs_temp_dir", None, "Fast local MMseqs2 scratch directory.")
-flags.DEFINE_integer(
-    "mmseqs_batch_max_sequences", None, "Maximum unique sequences per query database."
-)
-flags.DEFINE_integer(
-    "mmseqs_batch_max_residues", None, "Maximum residues per query database."
-)
-flags.DEFINE_float("mmseqs_e_value", 1e-4, "MMseqs2 search E-value cutoff.")
-flags.DEFINE_integer("mmseqs_threads", 8, "CPU threads for MMseqs2 operations.")
-
-for database_name in ("uniref90", "mgnify", "small_bfd", "uniprot"):
-    flags.DEFINE_string(
-        f"mmseqs_{database_name}_database_path",
-        None,
-        f"Explicit GPU-compatible MMseqs2 {database_name} database prefix.",
-    )
-    flags.DEFINE_string(
-        f"mmseqs_{database_name}_database_id",
-        None,
-        f"Immutable identifier for the {database_name} database build.",
-    )
-
-flags.DEFINE_integer(
-    "mmseqs_uniref90_max_sequences", 10_000, "Maximum UniRef90 hits per query."
-)
-flags.DEFINE_integer(
-    "mmseqs_mgnify_max_sequences", 5_000, "Maximum MGnify hits per query."
-)
-flags.DEFINE_integer(
-    "mmseqs_small_bfd_max_sequences", 5_000, "Maximum small-BFD hits per query."
-)
-flags.DEFINE_integer(
-    "mmseqs_uniprot_max_sequences", 50_000, "Maximum paired UniProt hits per query."
-)
+define_msa_search_flags(include_fasta_paths=True, include_summary_path=True)
 
 FLAGS = flags.FLAGS
-
-
-def _database(name: str) -> DatabaseSpec:
-    return DatabaseSpec(
-        name=name,
-        path=Path(getattr(FLAGS, f"mmseqs_{name}_database_path")),
-        identifier=getattr(FLAGS, f"mmseqs_{name}_database_id"),
-        max_sequences=getattr(FLAGS, f"mmseqs_{name}_max_sequences"),
-    )
 
 
 def main(argv) -> None:
@@ -81,9 +36,9 @@ def main(argv) -> None:
         output_dir=Path(FLAGS.msa_output_dir),
         temp_dir=Path(FLAGS.mmseqs_temp_dir),
         unpaired_databases=tuple(
-            _database(name) for name in ("uniref90", "mgnify", "small_bfd")
+            database_spec(FLAGS, name) for name in DATABASE_NAMES[:3]
         ),
-        paired_database=_database("uniprot"),
+        paired_database=database_spec(FLAGS, "uniprot"),
         max_sequences_per_batch=FLAGS.mmseqs_batch_max_sequences,
         max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
         threads=FLAGS.mmseqs_threads,
@@ -113,17 +68,8 @@ if __name__ == "__main__":
     flags.mark_flags_as_required(
         [
             "fasta_paths",
-            "msa_output_dir",
             "summary_path",
-            "mmseqs_binary_path",
-            "mmseqs_temp_dir",
-            "mmseqs_batch_max_sequences",
-            "mmseqs_batch_max_residues",
-            *[
-                f"mmseqs_{database_name}_{suffix}"
-                for database_name in ("uniref90", "mgnify", "small_bfd", "uniprot")
-                for suffix in ("database_path", "database_id")
-            ],
+            *required_msa_flag_names(),
         ]
     )
     app.run(main)

--- a/alphapulldown/scripts/create_batch_msas.py
+++ b/alphapulldown/scripts/create_batch_msas.py
@@ -41,6 +41,7 @@ def main(argv) -> None:
         max_residues_per_batch=FLAGS.mmseqs_batch_max_residues,
         threads=FLAGS.mmseqs_threads,
         e_value=FLAGS.mmseqs_e_value,
+        split_memory_limit=FLAGS.mmseqs_split_memory_limit,
     )
     result = MsaBatch(
         settings=settings,

--- a/alphapulldown/scripts/create_individual_features.py
+++ b/alphapulldown/scripts/create_individual_features.py
@@ -9,7 +9,6 @@ import json
 import lzma
 import os
 import pickle
-import re
 import shutil
 import sys
 import tempfile
@@ -45,6 +44,7 @@ from alphapulldown.utils.template_reuse import (
     msa_for_template_search,
     search_templates,
 )
+from alphapulldown.utils.sequence_types import get_af3_chain_kind
 
 # Try to import AlphaFold3, but it's optional
 AF3_IMPORT_ERROR = None
@@ -182,11 +182,6 @@ flags.DEFINE_boolean("multiple_mmts", False, "")
 
 FLAGS = flags.FLAGS
 
-AF3_DNA_BASES = frozenset("ACGTN")
-AF3_RNA_BASES = frozenset("ACGUN")
-AF3_PROTEIN_RESIDUES = frozenset("ACDEFGHIKLMNPQRSTVWYX")
-AF3_PROTEIN_ONLY_RESIDUES = AF3_PROTEIN_RESIDUES - (AF3_DNA_BASES | {"U"})
-
 AF3_PROTEIN_MSA_DATABASE_FLAGS = frozenset({
     "uniref90_database_path",
     "mgnify_database_path",
@@ -303,37 +298,6 @@ def check_template_date():
     if not FLAGS.max_template_date:
         logging.error("You have not provided a max_template_date. Please specify a date and run again.")
         sys.exit(1)
-
-def get_af3_chain_kind(description, sequence):
-    """Infer an AF3 chain kind, requiring an explicit hint for ambiguous alphabets."""
-    residues = set(sequence.upper())
-    if not residues:
-        raise ValueError("Sequence is empty.")
-
-    invalid_residues = residues - (AF3_PROTEIN_RESIDUES | {"U"})
-    if invalid_residues:
-        invalid_list = ", ".join(sorted(invalid_residues))
-        raise ValueError(f"Invalid sequence residues: {invalid_list}")
-
-    if residues <= AF3_RNA_BASES and "U" in residues:
-        return "rna"
-    if residues & AF3_PROTEIN_ONLY_RESIDUES:
-        return "protein"
-
-    description_tokens = {
-        token for token in re.split(r"[^A-Za-z0-9]+", description.lower()) if token
-    }
-    if "dna" in description_tokens:
-        return "dna"
-    if "rna" in description_tokens:
-        return "rna"
-    if {"protein", "prot", "peptide"} & description_tokens:
-        return "protein"
-
-    raise ValueError(
-        "Ambiguous sequence alphabet. Add 'DNA', 'RNA', or 'protein' to "
-        f"the FASTA description for '{description}' to disambiguate."
-    )
 
 def create_af3_chain(sequence, description, chain_id):
     """Construct an AF3 chain object for the provided sequence."""

--- a/alphapulldown/scripts/finalize_batch_features.py
+++ b/alphapulldown/scripts/finalize_batch_features.py
@@ -18,19 +18,14 @@ from alphapulldown.feature_batch import (
     protein_requests_from_fastas,
 )
 from alphapulldown.scripts import create_individual_features as legacy_features
+from alphapulldown.scripts._mmseqs2_cli import (
+    define_template_provenance_flags,
+    required_template_flag_names,
+)
 
 
 flags.DEFINE_string("msa_input_dir", None, "Directory containing MMseqs2 MSA bundles.")
-flags.DEFINE_string(
-    "template_seqres_database_id",
-    None,
-    "Immutable identity of the PDB seqres database used for templates.",
-)
-flags.DEFINE_string(
-    "template_mmcif_database_id",
-    None,
-    "Immutable identity of the mmCIF directory used for templates.",
-)
+define_template_provenance_flags()
 
 FLAGS = flags.FLAGS
 
@@ -84,8 +79,7 @@ if __name__ == "__main__":
             "output_dir",
             "data_dir",
             "max_template_date",
-            "template_seqres_database_id",
-            "template_mmcif_database_id",
+            *required_template_flag_names(),
         ]
     )
     app.run(main)

--- a/alphapulldown/scripts/finalize_batch_features.py
+++ b/alphapulldown/scripts/finalize_batch_features.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""CPU-only native AF3 template search and feature finalization stage."""
+
+from __future__ import annotations
+
+import os
+
+# AF3 imports JAX transitively; this CPU stage must never initialize a GPU.
+os.environ["JAX_PLATFORMS"] = "cpu"
+
+from pathlib import Path
+
+from absl import app, flags, logging
+
+from alphapulldown.feature_batch import (
+    FeatureFinalizationSettings,
+    FeatureFinalizer,
+    protein_requests_from_fastas,
+)
+from alphapulldown.scripts import create_individual_features as legacy_features
+
+
+flags.DEFINE_string("msa_input_dir", None, "Directory containing MMseqs2 MSA bundles.")
+flags.DEFINE_string(
+    "template_seqres_database_id",
+    None,
+    "Immutable identity of the PDB seqres database used for templates.",
+)
+flags.DEFINE_string(
+    "template_mmcif_database_id",
+    None,
+    "Immutable identity of the mmCIF directory used for templates.",
+)
+
+FLAGS = flags.FLAGS
+
+
+def main(argv) -> None:
+    del argv
+    if FLAGS.data_pipeline != "alphafold3":
+        raise ValueError("MMseqs2 MSA finalization requires --data_pipeline=alphafold3")
+    if FLAGS.keep_msas or FLAGS.skip_msa or FLAGS.path_to_mmt or FLAGS.use_mmseqs2:
+        raise ValueError(
+            "MMseqs2 MSA finalization cannot be combined with --keep_msas, "
+            "--skip_msa, --path_to_mmt, or --use_mmseqs2"
+        )
+
+    legacy_features.create_arguments()
+    pipeline = legacy_features.create_pipeline_af3()
+    metadata = legacy_features.get_af3_feature_metadata({"protein"}, skip_msa=True)
+    requests = protein_requests_from_fastas(FLAGS.fasta_paths)
+    result = FeatureFinalizer(
+        settings=FeatureFinalizationSettings(
+            output_dir=Path(FLAGS.output_dir),
+            msa_input_dir=Path(FLAGS.msa_input_dir),
+            max_template_date=FLAGS.max_template_date,
+            template_seqres_database_id=FLAGS.template_seqres_database_id,
+            template_mmcif_database_id=FLAGS.template_mmcif_database_id,
+            compress=FLAGS.compress_features,
+            base_metadata=metadata,
+        ),
+        af3_pipeline=pipeline,
+    ).generate(requests)
+    logging.info(
+        "AF3 feature finalization: %d written, %d reused, %d failed",
+        len(result.written),
+        len(result.reused),
+        len(result.failures),
+    )
+    if result.failures:
+        detail = ", ".join(
+            f"{failure.name} ({failure.error})" for failure in result.failures
+        )
+        raise RuntimeError(
+            f"AF3 feature finalization failed for {len(result.failures)} protein(s): {detail}"
+        )
+
+
+if __name__ == "__main__":
+    flags.mark_flags_as_required(
+        [
+            "fasta_paths",
+            "msa_input_dir",
+            "output_dir",
+            "data_dir",
+            "max_template_date",
+            "template_seqres_database_id",
+            "template_mmcif_database_id",
+        ]
+    )
+    app.run(main)

--- a/alphapulldown/utils/msa_quality.py
+++ b/alphapulldown/utils/msa_quality.py
@@ -1,0 +1,40 @@
+"""Backend-neutral MSA metrics for reproducible scientific comparisons."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _sequences(a3m: str) -> list[str]:
+    sequences = []
+    parts: list[str] = []
+    for line in a3m.splitlines():
+        if line.startswith(">"):
+            if parts:
+                sequences.append("".join(parts))
+            parts = []
+        elif line.strip():
+            parts.append(line.strip())
+    if parts:
+        sequences.append("".join(parts))
+    return sequences
+
+
+def measure_a3m(a3m: str, *, query_length: int) -> dict[str, Any]:
+    """Measure raw/unique depth and mean aligned non-gap query coverage."""
+    if query_length < 1:
+        raise ValueError("query_length must be positive")
+    sequences = _sequences(a3m)
+    coverages = []
+    for sequence in sequences:
+        aligned = [residue for residue in sequence if not residue.islower()]
+        coverages.append(
+            min(1.0, sum(residue not in "-." for residue in aligned) / query_length)
+        )
+    return {
+        "depth": len(sequences),
+        "unique_depth": len(set(sequences)),
+        "mean_non_gap_coverage": (
+            sum(coverages) / len(coverages) if coverages else 0.0
+        ),
+    }

--- a/alphapulldown/utils/sequence_types.py
+++ b/alphapulldown/utils/sequence_types.py
@@ -1,0 +1,43 @@
+"""Lightweight sequence classification shared by AlphaFold feature adapters."""
+
+from __future__ import annotations
+
+import re
+
+
+AF3_DNA_BASES = frozenset("ACGTN")
+AF3_RNA_BASES = frozenset("ACGUN")
+AF3_PROTEIN_RESIDUES = frozenset("ACDEFGHIKLMNPQRSTVWYX")
+AF3_PROTEIN_ONLY_RESIDUES = AF3_PROTEIN_RESIDUES - (AF3_DNA_BASES | {"U"})
+
+
+def get_af3_chain_kind(description: str, sequence: str) -> str:
+    """Infer an AF3 chain kind, requiring a hint for ambiguous alphabets."""
+    residues = set(sequence.upper())
+    if not residues:
+        raise ValueError("Sequence is empty.")
+
+    invalid_residues = residues - (AF3_PROTEIN_RESIDUES | {"U"})
+    if invalid_residues:
+        invalid_list = ", ".join(sorted(invalid_residues))
+        raise ValueError(f"Invalid sequence residues: {invalid_list}")
+
+    if residues <= AF3_RNA_BASES and "U" in residues:
+        return "rna"
+    if residues & AF3_PROTEIN_ONLY_RESIDUES:
+        return "protein"
+
+    description_tokens = {
+        token for token in re.split(r"[^A-Za-z0-9]+", description.lower()) if token
+    }
+    if "dna" in description_tokens:
+        return "dna"
+    if "rna" in description_tokens:
+        return "rna"
+    if {"protein", "prot", "peptide"} & description_tokens:
+        return "protein"
+
+    raise ValueError(
+        "Ambiguous sequence alphabet. Add 'DNA', 'RNA', or 'protein' to "
+        f"the FASTA description for '{description}' to disambiguate."
+    )

--- a/docker/alphafold2.dockerfile
+++ b/docker/alphafold2.dockerfile
@@ -4,6 +4,7 @@
 # FROM line can interpolate them.
 ARG CUDA=12.2.2
 ARG MMSEQS_VERSION=18-8cc5c
+ARG MMSEQS_COMMIT=8cc5ce367b5638c4306c2d7cfc652dd099a4643f
 ARG MMSEQS_GPU_SHA256=83969dd5c7d4c32858c2fc9a4d1024c15e8fe5da768ce76e787ab0195ffd64e7
 
 # ---------------------------------------------------------------------------
@@ -42,6 +43,7 @@ RUN set -eux; \
 FROM nvidia/cuda:${CUDA}-cudnn8-runtime-ubuntu20.04
 ARG CUDA
 ARG MMSEQS_VERSION
+ARG MMSEQS_COMMIT
 ARG MMSEQS_GPU_SHA256
 
 SHELL ["/bin/bash","-o","pipefail","-c"]
@@ -74,7 +76,7 @@ RUN set -eux; \
     echo "${MMSEQS_GPU_SHA256}  ${archive}" | sha256sum -c -; \
     tar -xzf "${archive}" -C /opt; \
     rm -f "${archive}"; \
-    test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_VERSION}"
+    test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_COMMIT}"
 
 # Micromamba bootstrap (smaller than Miniforge)
 ENV MAMBA_ROOT_PREFIX=/opt/conda

--- a/docker/alphafold2.dockerfile
+++ b/docker/alphafold2.dockerfile
@@ -3,6 +3,8 @@
 # Global build args must be declared before the first FROM so that every stage's
 # FROM line can interpolate them.
 ARG CUDA=12.2.2
+ARG MMSEQS_VERSION=18-8cc5c
+ARG MMSEQS_GPU_SHA256=83969dd5c7d4c32858c2fc9a4d1024c15e8fe5da768ce76e787ab0195ffd64e7
 
 # ---------------------------------------------------------------------------
 # Patched HHblits, built in a throwaway stage so the runtime image never gains
@@ -39,6 +41,8 @@ RUN set -eux; \
 
 FROM nvidia/cuda:${CUDA}-cudnn8-runtime-ubuntu20.04
 ARG CUDA
+ARG MMSEQS_VERSION
+ARG MMSEQS_GPU_SHA256
 
 SHELL ["/bin/bash","-o","pipefail","-c"]
 
@@ -59,6 +63,19 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       ca-certificates curl bzip2 tzdata openssh-client; \
     rm -rf /var/lib/apt/lists/*
 
+# Keep MMseqs2 outside the Python environment: the GPU release is a standalone
+# executable used by AF3 feature batches and is also present in the AF2 image so
+# both prediction images expose the same verified runtime toolchain.
+RUN set -eux; \
+    archive=/tmp/mmseqs-linux-gpu.tar.gz; \
+    curl -fsSL \
+      "https://github.com/soedinglab/MMseqs2/releases/download/${MMSEQS_VERSION}/mmseqs-linux-gpu.tar.gz" \
+      -o "${archive}"; \
+    echo "${MMSEQS_GPU_SHA256}  ${archive}" | sha256sum -c -; \
+    tar -xzf "${archive}" -C /opt; \
+    rm -f "${archive}"; \
+    test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_VERSION}"
+
 # Micromamba bootstrap (smaller than Miniforge)
 ENV MAMBA_ROOT_PREFIX=/opt/conda
 RUN set -eux; \
@@ -66,7 +83,7 @@ RUN set -eux; \
     curl -k -L https://micro.mamba.pm/api/micromamba/linux-64/latest \
       | tar -xj -C /usr/local/bin --strip-components=1 bin/micromamba
 
-ENV PATH="/opt/conda/bin:${PATH}"
+ENV PATH="/opt/mmseqs/bin:/opt/conda/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/conda/lib:${LD_LIBRARY_PATH}"
 
 RUN set -eux; \

--- a/docker/alphafold3.dockerfile
+++ b/docker/alphafold3.dockerfile
@@ -152,6 +152,9 @@ RUN uv pip install --no-cache "modelcif>=1.6" && \
       test/unit/test_feature_metadata.py::test_embedded_json_is_accepted_and_round_tripped_by_vanilla_alphafold3 \
       test/unit/test_af3_modelcif.py::test_augment_real_af3_modelcif_preserves_comments_and_is_modelcif_readable \
       test/unit/test_convert_to_modelcif_helpers.py && \
+    MMSEQS_INTEGRATION_BINARY=/opt/mmseqs/bin/mmseqs \
+      python -m pytest -q -o addopts="-ra --strict-markers" \
+      test/integration/test_mmseqs2_command_contract.py && \
     touch /tmp/af3-compatibility-tests-passed
 
 FROM base AS runtime

--- a/docker/alphafold3.dockerfile
+++ b/docker/alphafold3.dockerfile
@@ -147,6 +147,8 @@ WORKDIR /app/AlphaPulldown
 RUN uv pip install --no-cache "modelcif>=1.6" && \
     python -c "from alphafold3.common import folding_input; import alphafold3.structure.mmcif; import ihm; import modelcif.reader" && \
     python -m pytest -q \
+      test/unit/test_feature_batch.py \
+      test/unit/test_create_batch_features.py \
       test/unit/test_feature_metadata.py::test_embedded_json_is_accepted_and_round_tripped_by_vanilla_alphafold3 \
       test/unit/test_af3_modelcif.py::test_augment_real_af3_modelcif_preserves_comments_and_is_modelcif_readable \
       test/unit/test_convert_to_modelcif_helpers.py && \

--- a/docker/alphafold3.dockerfile
+++ b/docker/alphafold3.dockerfile
@@ -1,8 +1,10 @@
 ARG MMSEQS_VERSION=18-8cc5c
+ARG MMSEQS_COMMIT=8cc5ce367b5638c4306c2d7cfc652dd099a4643f
 ARG MMSEQS_GPU_SHA256=83969dd5c7d4c32858c2fc9a4d1024c15e8fe5da768ce76e787ab0195ffd64e7
 
 FROM nvidia/cuda:12.6.3-base-ubuntu24.04 AS base
 ARG MMSEQS_VERSION
+ARG MMSEQS_COMMIT
 ARG MMSEQS_GPU_SHA256
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -45,7 +47,7 @@ RUN set -eux; \
     echo "${MMSEQS_GPU_SHA256}  ${archive}" | sha256sum -c -; \
     tar -xzf "${archive}" -C /opt; \
     rm -f "${archive}"; \
-    test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_VERSION}"
+    test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_COMMIT}"
 
 # Force gcc-12 (avoid gcc-13 ICE on 24.04)
 ENV CC=gcc-12

--- a/docker/alphafold3.dockerfile
+++ b/docker/alphafold3.dockerfile
@@ -1,11 +1,16 @@
+ARG MMSEQS_VERSION=18-8cc5c
+ARG MMSEQS_GPU_SHA256=83969dd5c7d4c32858c2fc9a4d1024c15e8fe5da768ce76e787ab0195ffd64e7
+
 FROM nvidia/cuda:12.6.3-base-ubuntu24.04 AS base
+ARG MMSEQS_VERSION
+ARG MMSEQS_GPU_SHA256
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV VIRTUAL_ENV=/opt/venv
 ENV UV_PROJECT_ENVIRONMENT=${VIRTUAL_ENV}
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
-ENV PATH="/hmmer/bin:${VIRTUAL_ENV}/bin:${PATH}"
+ENV PATH="/opt/mmseqs/bin:/hmmer/bin:${VIRTUAL_ENV}/bin:${PATH}"
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # ---------------------------------------------------------------------
@@ -30,6 +35,17 @@ RUN apt-get update && \
         zlib1g-dev \
         zstd \
     && rm -rf /var/lib/apt/lists/*
+
+# Install the standalone GPU release, verified independently of Python/PyPI.
+RUN set -eux; \
+    archive=/tmp/mmseqs-linux-gpu.tar.gz; \
+    wget -q \
+      "https://github.com/soedinglab/MMseqs2/releases/download/${MMSEQS_VERSION}/mmseqs-linux-gpu.tar.gz" \
+      -O "${archive}"; \
+    echo "${MMSEQS_GPU_SHA256}  ${archive}" | sha256sum -c -; \
+    tar -xzf "${archive}" -C /opt; \
+    rm -f "${archive}"; \
+    test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_VERSION}"
 
 # Force gcc-12 (avoid gcc-13 ICE on 24.04)
 ENV CC=gcc-12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ packages = [
 ]
 script-files = [
   "./alphapulldown/scripts/create_individual_features.py",
+  "./alphapulldown/scripts/create_batch_features.py",
   "./alphapulldown/scripts/run_multimer_jobs.py",
   "./alphapulldown/scripts/generate_alphafold_server_json.py",
   "./alphapulldown/analysis_pipeline/create_notebook.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,9 @@ packages = [
 script-files = [
   "./alphapulldown/scripts/create_individual_features.py",
   "./alphapulldown/scripts/create_batch_features.py",
+  "./alphapulldown/scripts/create_batch_msas.py",
+  "./alphapulldown/scripts/finalize_batch_features.py",
+  "./alphapulldown/scripts/compare_msa_backends.py",
   "./alphapulldown/scripts/run_multimer_jobs.py",
   "./alphapulldown/scripts/generate_alphafold_server_json.py",
   "./alphapulldown/analysis_pipeline/create_notebook.py",

--- a/test/integration/test_mmseqs2_command_contract.py
+++ b/test/integration/test_mmseqs2_command_contract.py
@@ -1,0 +1,88 @@
+"""Opt-in contract test against a real MMseqs2 executable and tiny database."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.external_tools]
+
+try:
+    from alphafold3.cpp import msa_conversion as _msa_conversion  # noqa: F401
+except ImportError as exc:
+    pytest.skip(
+        f"AlphaFold 3 MSA conversion is unavailable: {exc}", allow_module_level=True
+    )
+
+from alphapulldown.feature_batch import (  # noqa: E402
+    DatabaseSpec,
+    FeatureRequest,
+    MsaBatch,
+    MsaBatchSettings,
+    SubprocessMmseqsProcess,
+)
+
+
+def _run(binary: Path, *arguments: str) -> None:
+    subprocess.run(
+        [str(binary), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_real_createdb_padded_search_result2msa_and_unpack_contract(tmp_path):
+    configured_binary = os.environ.get("MMSEQS_INTEGRATION_BINARY")
+    if not configured_binary:
+        pytest.skip("set MMSEQS_INTEGRATION_BINARY to run the real command contract")
+    binary = Path(configured_binary)
+    if not binary.is_file():
+        pytest.fail(f"MMSEQS_INTEGRATION_BINARY does not exist: {binary}")
+
+    query_sequence = "MKTAYIAKQRQISFVKSHFSRQDILDLWIYHTQGYFPQYQKVEKLLKQGADVVVT"
+    target_sequence = query_sequence[:-1] + "A"
+    target_fasta = tmp_path / "target.fasta"
+    target_fasta.write_text(
+        f">target_hit expected description OX=9606\n{target_sequence}\n",
+        encoding="utf-8",
+    )
+    target_db = tmp_path / "target"
+    padded_db = tmp_path / "target_gpu"
+    _run(binary, "createdb", str(target_fasta), str(target_db), "--threads", "1")
+    _run(binary, "makepaddedseqdb", str(target_db), str(padded_db), "--threads", "1")
+
+    databases = tuple(
+        DatabaseSpec(name=name, path=padded_db, identifier="tiny-padded-v1")
+        for name in ("uniref90", "mgnify", "small_bfd", "uniprot")
+    )
+    settings = MsaBatchSettings(
+        output_dir=tmp_path / "msas",
+        temp_dir=tmp_path / "work",
+        unpaired_databases=databases[:3],
+        paired_database=databases[3],
+        max_sequences_per_batch=8,
+        max_residues_per_batch=1_000,
+        threads=2,
+    )
+
+    use_gpu = os.environ.get("MMSEQS_INTEGRATION_GPU") == "1"
+    result = MsaBatch(
+        settings=settings,
+        mmseqs_process=SubprocessMmseqsProcess(binary, gpu=use_gpu),
+    ).generate([FeatureRequest(name="query", sequence=query_sequence)])
+
+    assert result.failures == ()
+    payload = json.loads(
+        (settings.output_dir / "query_mmseqs_msa.json").read_text(encoding="utf-8")
+    )
+    assert "target_hit expected description OX=9606" in payload["unpairedMsa"]
+    assert "target_hit expected description OX=9606" in payload["pairedMsa"]
+    assert payload["provenance"]["search_mode"] == (
+        "gpu" if use_gpu else "cpu-contract"
+    )

--- a/test/integration/test_mmseqs2_command_contract.py
+++ b/test/integration/test_mmseqs2_command_contract.py
@@ -84,5 +84,5 @@ def test_real_createdb_padded_search_result2msa_and_unpack_contract(tmp_path):
     assert "target_hit expected description OX=9606" in payload["unpairedMsa"]
     assert "target_hit expected description OX=9606" in payload["pairedMsa"]
     assert payload["provenance"]["search_mode"] == (
-        "gpu" if use_gpu else "cpu-contract"
+        "gpu" if use_gpu else "cpu"
     )

--- a/test/unit/test_create_batch_features.py
+++ b/test/unit/test_create_batch_features.py
@@ -49,6 +49,42 @@ def test_import_forces_jax_to_cpu_without_hiding_gpu_from_mmseqs():
     }
 
 
+def test_msa_stage_imports_neither_jax_nor_alphafold():
+    repository = Path(__file__).resolve().parents[2]
+    environment = os.environ.copy()
+    environment["OPENBLAS_NUM_THREADS"] = "1"
+    environment["OMP_NUM_THREADS"] = "1"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(repository), environment.get("PYTHONPATH")))
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, sys\n"
+                "import alphapulldown.scripts.create_batch_msas\n"
+                "print(json.dumps({'jax': 'jax' in sys.modules, "
+                "'af2': 'alphafold' in sys.modules, "
+                "'af3': 'alphafold3' in sys.modules}))\n"
+            ),
+        ],
+        cwd=repository,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert json.loads(completed.stdout.splitlines()[-1]) == {
+        "jax": False,
+        "af2": False,
+        "af3": False,
+    }
+
+
 def test_cli_adapter_rejects_non_protein_af3_fasta(tmp_path: Path):
     fasta = tmp_path / "dna.fasta"
     fasta.write_text(">DNA example\nACGT\n", encoding="utf-8")

--- a/test/unit/test_create_batch_features.py
+++ b/test/unit/test_create_batch_features.py
@@ -85,7 +85,7 @@ def test_msa_stage_imports_neither_jax_nor_alphafold():
     }
 
 
-def test_batch_entry_points_share_one_idempotent_mmseqs_flag_schema():
+def test_lightweight_mmseqs_flag_schema_can_be_registered_twice_without_jax():
     repository = Path(__file__).resolve().parents[2]
     environment = os.environ.copy()
     environment["OPENBLAS_NUM_THREADS"] = "1"
@@ -99,9 +99,21 @@ def test_batch_entry_points_share_one_idempotent_mmseqs_flag_schema():
             sys.executable,
             "-c",
             (
-                "from absl import flags\n"
-                "import alphapulldown.scripts.create_batch_features\n"
+                "import importlib.abc, sys\n"
+                "class BlockJax(importlib.abc.MetaPathFinder):\n"
+                "    def find_spec(self, fullname, path, target=None):\n"
+                "        if fullname == 'jax' or fullname.startswith('jax.'):\n"
+                "            raise ModuleNotFoundError('JAX import forbidden')\n"
+                "        return None\n"
+                "sys.meta_path.insert(0, BlockJax())\n"
                 "import alphapulldown.scripts.create_batch_msas\n"
+                "from alphapulldown.scripts._mmseqs2_cli import "
+                "define_msa_search_flags, define_template_provenance_flags\n"
+                "define_msa_search_flags(include_fasta_paths=True, "
+                "include_summary_path=True)\n"
+                "define_template_provenance_flags()\n"
+                "define_template_provenance_flags()\n"
+                "from absl import flags\n"
                 "print(flags.FLAGS['mmseqs_uniref90_max_sequences'].default)\n"
             ),
         ],

--- a/test/unit/test_create_batch_features.py
+++ b/test/unit/test_create_batch_features.py
@@ -25,11 +25,14 @@ def test_import_forces_jax_to_cpu_without_hiding_gpu_from_mmseqs():
             sys.executable,
             "-c",
             (
-                "import json, os; "
-                "import alphapulldown.scripts.create_batch_features; "
+                "import json, os\n"
+                "try:\n"
+                "    import alphapulldown.scripts.create_batch_features\n"
+                "except ImportError:\n"
+                "    pass\n"
                 "print(json.dumps({"
                 "'jax': os.environ.get('JAX_PLATFORMS'), "
-                "'cuda': os.environ.get('CUDA_VISIBLE_DEVICES')}))"
+                "'cuda': os.environ.get('CUDA_VISIBLE_DEVICES')}))\n"
             ),
         ],
         cwd=repository,

--- a/test/unit/test_create_batch_features.py
+++ b/test/unit/test_create_batch_features.py
@@ -85,6 +85,38 @@ def test_msa_stage_imports_neither_jax_nor_alphafold():
     }
 
 
+def test_batch_entry_points_share_one_idempotent_mmseqs_flag_schema():
+    repository = Path(__file__).resolve().parents[2]
+    environment = os.environ.copy()
+    environment["OPENBLAS_NUM_THREADS"] = "1"
+    environment["OMP_NUM_THREADS"] = "1"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(repository), environment.get("PYTHONPATH")))
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from absl import flags\n"
+                "import alphapulldown.scripts.create_batch_features\n"
+                "import alphapulldown.scripts.create_batch_msas\n"
+                "print(flags.FLAGS['mmseqs_uniref90_max_sequences'].default)\n"
+            ),
+        ],
+        cwd=repository,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.splitlines()[-1] == "10000"
+
+
 def test_cli_adapter_rejects_non_protein_af3_fasta(tmp_path: Path):
     fasta = tmp_path / "dna.fasta"
     fasta.write_text(">DNA example\nACGT\n", encoding="utf-8")

--- a/test/unit/test_create_batch_features.py
+++ b/test/unit/test_create_batch_features.py
@@ -1,8 +1,49 @@
+import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
-from alphapulldown.scripts.create_batch_features import _feature_requests
+from alphapulldown.scripts.create_batch_features import FLAGS, _feature_requests
+
+
+def test_import_forces_jax_to_cpu_without_hiding_gpu_from_mmseqs():
+    repository = Path(__file__).resolve().parents[2]
+    environment = os.environ.copy()
+    environment["JAX_PLATFORMS"] = "cuda"
+    environment["CUDA_VISIBLE_DEVICES"] = "7"
+    environment["OPENBLAS_NUM_THREADS"] = "1"
+    environment["OMP_NUM_THREADS"] = "1"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(repository), environment.get("PYTHONPATH")))
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, os; "
+                "import alphapulldown.scripts.create_batch_features; "
+                "print(json.dumps({"
+                "'jax': os.environ.get('JAX_PLATFORMS'), "
+                "'cuda': os.environ.get('CUDA_VISIBLE_DEVICES')}))"
+            ),
+        ],
+        cwd=repository,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert json.loads(completed.stdout.splitlines()[-1]) == {
+        "jax": "cpu",
+        "cuda": "7",
+    }
 
 
 def test_cli_adapter_rejects_non_protein_af3_fasta(tmp_path: Path):
@@ -11,3 +52,7 @@ def test_cli_adapter_rejects_non_protein_af3_fasta(tmp_path: Path):
 
     with pytest.raises(ValueError, match="protein"):
         _feature_requests([str(fasta)])
+
+
+def test_cli_defaults_to_the_binary_bundled_in_prediction_images():
+    assert FLAGS["mmseqs_binary_path"].default == "/opt/mmseqs/bin/mmseqs"

--- a/test/unit/test_create_batch_features.py
+++ b/test/unit/test_create_batch_features.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+import pytest
+
+from alphapulldown.scripts.create_batch_features import _feature_requests
+
+
+def test_cli_adapter_rejects_non_protein_af3_fasta(tmp_path: Path):
+    fasta = tmp_path / "dna.fasta"
+    fasta.write_text(">DNA example\nACGT\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="protein"):
+        _feature_requests([str(fasta)])

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -650,7 +650,7 @@ def test_all_native_af3_msa_databases_must_be_explicit(tmp_path):
 
     with pytest.raises(
         ValueError,
-        match="uniref90, mgnify, and small_bfd",
+        match="uniref90, mgnify, small_bfd",
     ):
         batch.generate([FeatureRequest(name="alpha", sequence="ACDE")])
 
@@ -951,3 +951,33 @@ def test_database_rebuild_invalidates_cache_even_with_same_identifier(tmp_path: 
     result = MsaBatch(settings=settings, mmseqs_process=second).generate((request,))
     assert [artifact.name for artifact in result.written] == ["alpha"]
     assert not result.reused
+
+
+def test_database_roles_are_named_not_positional():
+    """A reordered name tuple must not be able to swap paired for unpaired."""
+    from alphapulldown import feature_batch as fb
+
+    assert fb.DATABASE_NAMES == (*fb.UNPAIRED_DATABASE_NAMES, fb.PAIRED_DATABASE_NAME)
+    assert fb.PAIRED_DATABASE_NAME not in fb.UNPAIRED_DATABASE_NAMES
+    assert set(fb.DEFAULT_MAX_SEQUENCES) == set(fb.DATABASE_NAMES)
+
+
+def test_database_selection_assigns_roles_from_flags():
+    from types import SimpleNamespace
+
+    from alphapulldown import feature_batch as fb
+    from alphapulldown.scripts._mmseqs2_cli import database_selection
+
+    class _Flag:
+        def __init__(self, value):
+            self.value = value
+
+    values = {}
+    for name in fb.DATABASE_NAMES:
+        values[f"mmseqs_{name}_database_path"] = _Flag(f"/db/{name}")
+        values[f"mmseqs_{name}_database_id"] = _Flag(f"{name}-id")
+        values[f"mmseqs_{name}_max_sequences"] = _Flag(None)
+
+    selection = database_selection(values)
+    assert [db.name for db in selection.unpaired] == list(fb.UNPAIRED_DATABASE_NAMES)
+    assert selection.paired.name == fb.PAIRED_DATABASE_NAME

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -911,3 +911,43 @@ def test_compressed_artifact_uses_existing_af3_filename_and_is_cacheable(tmp_pat
         af3_pipeline=PassthroughAf3Pipeline(),
     ).generate([request])
     assert [item.path for item in reused.reused] == [artifact]
+
+
+class NoHitMmseqsProcess(FakeMmseqsProcess):
+    """A database that is valid and searchable but contains nothing relevant."""
+
+    def unpack_msa(self, query_db: Path, msa_db: Path, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for index, (query_id, sequence) in enumerate(self._queries[query_db]):
+            (output_dir / f"{index}.a3m").write_text(
+                f">{query_id}\n{sequence}\n", encoding="utf-8"
+            )
+
+
+def test_zero_hit_search_is_recorded_as_query_only(tmp_path: Path):
+    settings = _msa_settings(_settings(tmp_path))
+    result = MsaBatch(
+        settings=settings, mmseqs_process=NoHitMmseqsProcess()
+    ).generate((FeatureRequest(name="orphan", sequence="MKVLA"),))
+
+    assert not result.failures
+    assert result.query_only == ("orphan",)
+    payload = json.loads((settings.output_dir / "orphan_mmseqs_msa.json").read_text())
+    assert payload["unpairedDepth"] == 1
+    assert payload["pairedDepth"] == 1
+
+
+def test_database_rebuild_invalidates_cache_even_with_same_identifier(tmp_path: Path):
+    settings = _msa_settings(_settings(tmp_path))
+    request = FeatureRequest(name="alpha", sequence="MKVLA")
+    process = FakeMmseqsProcess()
+    MsaBatch(settings=settings, mmseqs_process=process).generate((request,))
+
+    # Same configured identifier, different database content on disk.
+    Path(f"{settings.unpaired_databases[0].path}.index").write_text(
+        "rebuilt", encoding="utf-8"
+    )
+    second = FakeMmseqsProcess()
+    result = MsaBatch(settings=settings, mmseqs_process=second).generate((request,))
+    assert [artifact.name for artifact in result.written] == ["alpha"]
+    assert not result.reused

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -10,6 +10,7 @@ import pytest
 
 _REAL_FOLDING_INPUT = pytest.importorskip("alphafold3.common.folding_input")
 _REAL_AF3_PIPELINE = pytest.importorskip("alphafold3.data.pipeline")
+_REAL_MSA_CONVERSION = pytest.importorskip("alphafold3.cpp.msa_conversion")
 
 from alphapulldown.feature_batch import (
     DatabaseSpec,
@@ -18,21 +19,32 @@ from alphapulldown.feature_batch import (
     FeatureRequest,
     SubprocessMmseqsProcess,
 )
+from alphapulldown.utils.feature_metadata import (
+    embed_metadata_in_af3_json,
+    extract_metadata_from_af3_json,
+)
 
 
 @pytest.fixture(autouse=True)
 def _use_real_af3_modules(monkeypatch):
     """Insulate these integration tests from another module's AF3 stubs."""
     common_package = sys.modules["alphafold3.common"]
+    cpp_package = sys.modules["alphafold3.cpp"]
     data_package = sys.modules["alphafold3.data"]
     monkeypatch.setitem(
         sys.modules, "alphafold3.common.folding_input", _REAL_FOLDING_INPUT
     )
     monkeypatch.setitem(sys.modules, "alphafold3.data.pipeline", _REAL_AF3_PIPELINE)
+    monkeypatch.setitem(
+        sys.modules, "alphafold3.cpp.msa_conversion", _REAL_MSA_CONVERSION
+    )
     monkeypatch.setattr(
         common_package, "folding_input", _REAL_FOLDING_INPUT, raising=False
     )
     monkeypatch.setattr(data_package, "pipeline", _REAL_AF3_PIPELINE, raising=False)
+    monkeypatch.setattr(
+        cpp_package, "msa_conversion", _REAL_MSA_CONVERSION, raising=False
+    )
 
 
 class FakeMmseqsProcess:
@@ -122,6 +134,22 @@ class FirstSequenceFailsMmseqs(FakeMmseqsProcess):
         super().search(query_db, database, result_db, work_dir, settings)
 
 
+class FullHeaderAlignedFastaMmseqs(FakeMmseqsProcess):
+    def unpack_msa(self, query_db: Path, msa_db: Path, output_dir: Path) -> None:
+        del msa_db
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for index, (query_id, sequence) in enumerate(self._queries[query_db]):
+            assert sequence == "ACDE"
+            (output_dir / f"{index}.fasta").write_text(
+                f">{query_id} query description\n"
+                "AC-DE\n"
+                ">sp|P12345|KINASE_HUMAN Protein kinase OS=Homo sapiens "
+                "OX=9606 GN=KIN1\n"
+                "ACXDE\n",
+                encoding="utf-8",
+            )
+
+
 class PassthroughAf3Pipeline:
     def process(self, fold_input):
         return fold_input
@@ -141,6 +169,31 @@ def test_subprocess_adapter_identity_comes_from_mmseqs_version(tmp_path):
         SubprocessMmseqsProcess(binary).identity()
         == "MMseqs2 Version: gpu-build-18"
     )
+
+
+def test_subprocess_adapter_requests_aligned_fasta_output(tmp_path):
+    binary = tmp_path / "mmseqs"
+    arguments = Path(f"{binary}.arguments")
+    binary.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$@\" > \"${0}.arguments\"\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    database = DatabaseSpec(
+        name="uniprot", path=tmp_path / "uniprot", identifier="fixture"
+    )
+
+    SubprocessMmseqsProcess(binary).result_to_msa(
+        tmp_path / "query",
+        database,
+        tmp_path / "result",
+        tmp_path / "msa",
+    )
+
+    command = arguments.read_text(encoding="utf-8").splitlines()
+    assert command[0] == "result2msa"
+    assert command[command.index("--msa-format-mode") + 1] == "2"
 
 
 def _native_pipeline_with_no_template_hits(tmp_path: Path):
@@ -235,6 +288,29 @@ def test_duplicate_sequences_are_searched_once_and_create_standard_artifacts(tmp
         assert protein["unpairedMsa"].count(">query") == 1
         assert ">uniprot_hit" in protein["pairedMsa"]
         assert protein["templates"] == []
+
+
+def test_aligned_fasta_conversion_preserves_taxon_header_and_insertions(tmp_path):
+    batch = FeatureBatch(
+        settings=_settings(tmp_path),
+        mmseqs_process=FullHeaderAlignedFastaMmseqs(),
+        af3_pipeline=PassthroughAf3Pipeline(),
+    )
+
+    result = batch.generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+    assert result.failures == ()
+    payload = json.loads(
+        (tmp_path / "features" / "alpha_af3_input.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    paired_msa = payload["sequences"][0]["protein"]["pairedMsa"]
+    assert (
+        ">sp|P12345|KINASE_HUMAN Protein kinase OS=Homo sapiens "
+        "OX=9606 GN=KIN1\n" in paired_msa
+    )
+    assert "\nACxDE\n" in paired_msa
 
 
 def test_matching_artifact_is_reused_without_external_search(tmp_path):
@@ -438,6 +514,35 @@ def test_changed_mmseqs_identity_regenerates_cached_sequence(tmp_path):
     assert [artifact.name for artifact in second.written] == ["alpha"]
     assert len(second_process._queries) == 1
     assert second_process.identity_calls == 1
+
+
+def test_legacy_alignment_schema_regenerates_cached_sequence(tmp_path):
+    settings = _settings(tmp_path)
+    request = FeatureRequest(name="alpha", sequence="ACDE")
+    FeatureBatch(
+        settings=settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+    artifact = settings.output_dir / "alpha_af3_input.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    metadata = extract_metadata_from_af3_json(payload)[0]
+    metadata["other"]["mmseqs2_gpu"]["schema_version"] = 2
+    artifact.write_text(
+        json.dumps(embed_metadata_in_af3_json(payload, metadata)),
+        encoding="utf-8",
+    )
+    process = FakeMmseqsProcess()
+
+    result = FeatureBatch(
+        settings=settings,
+        mmseqs_process=process,
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+
+    assert result.reused == ()
+    assert [item.name for item in result.written] == ["alpha"]
+    assert len(process._queries) == 1
 
 
 def test_cached_sequence_supplies_another_name_without_external_search(tmp_path):

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -26,6 +26,8 @@ from alphapulldown.feature_batch import (
     FeatureFinalizer,
     FeatureRequest,
     MsaBatch,
+    MsaArtifact,
+    MsaBatchResult,
     MsaBatchSettings,
     SubprocessMmseqsProcess,
     write_batch_summary,
@@ -138,6 +140,16 @@ class MissingUnpackOutputMmseqs(FakeMmseqsProcess):
         super().unpack_msa(query_db, msa_db, output_dir)
 
 
+class EmptyUnpackOutputMmseqs(FakeMmseqsProcess):
+    def unpack_msa(self, query_db: Path, msa_db: Path, output_dir: Path) -> None:
+        if msa_db.read_text(encoding="utf-8") == "mgnify":
+            output_dir.mkdir(parents=True, exist_ok=True)
+            for index, _ in enumerate(self._queries[query_db]):
+                (output_dir / f"{index}.fasta").write_text("", encoding="utf-8")
+            return
+        super().unpack_msa(query_db, msa_db, output_dir)
+
+
 class ForbiddenMmseqsProcess:
     def identity(self) -> str:
         return "mmseqs-fixture-1"
@@ -191,6 +203,12 @@ class CountingAf3Pipeline(PassthroughAf3Pipeline):
     def process(self, fold_input):
         self.calls += 1
         return super().process(fold_input)
+
+
+class FailingAf3Pipeline:
+    def process(self, fold_input):
+        del fold_input
+        raise RuntimeError("fixture template search failure")
 
 
 def test_subprocess_adapter_identity_comes_from_mmseqs_version(tmp_path):
@@ -322,6 +340,33 @@ def _settings(tmp_path: Path) -> FeatureBatchSettings:
     )
 
 
+def _msa_settings(settings: FeatureBatchSettings) -> MsaBatchSettings:
+    return MsaBatchSettings(
+        output_dir=settings.msa_output_dir,
+        temp_dir=settings.temp_dir,
+        unpaired_databases=settings.unpaired_databases,
+        paired_database=settings.paired_database,
+        max_sequences_per_batch=settings.max_sequences_per_batch,
+        max_residues_per_batch=settings.max_residues_per_batch,
+        threads=settings.threads,
+        e_value=settings.e_value,
+    )
+
+
+def _finalization_settings(
+    settings: FeatureBatchSettings,
+) -> FeatureFinalizationSettings:
+    return FeatureFinalizationSettings(
+        output_dir=settings.output_dir,
+        msa_input_dir=settings.msa_output_dir,
+        max_template_date=settings.max_template_date,
+        template_seqres_database_id=settings.template_seqres_database_id,
+        template_mmcif_database_id=settings.template_mmcif_database_id,
+        compress=settings.compress,
+        base_metadata=settings.base_metadata,
+    )
+
+
 def test_duplicate_sequences_are_searched_once_and_create_standard_artifacts(tmp_path):
     batch = FeatureBatch(
         settings=_settings(tmp_path),
@@ -359,7 +404,7 @@ def test_missing_unpack_output_fails_instead_of_caching_query_only_msa(tmp_path)
     settings = _settings(tmp_path)
 
     result = MsaBatch(
-        settings=settings,
+        settings=_msa_settings(settings),
         mmseqs_process=MissingUnpackOutputMmseqs(),
     ).generate([FeatureRequest(name="alpha", sequence="ACDE")])
 
@@ -369,38 +414,154 @@ def test_missing_unpack_output_fails_instead_of_caching_query_only_msa(tmp_path)
     assert not (settings.msa_output_dir / "alpha_mmseqs_msa.json").exists()
 
 
+def test_empty_unpack_output_fails_instead_of_caching_query_only_msa(tmp_path):
+    settings = _settings(tmp_path)
+
+    result = MsaBatch(
+        settings=_msa_settings(settings),
+        mmseqs_process=EmptyUnpackOutputMmseqs(),
+    ).generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+    assert result.written == ()
+    assert [failure.name for failure in result.failures] == ["alpha"]
+    assert "mgnify" in result.failures[0].error
+    assert "no FASTA records" in result.failures[0].error
+    assert not (settings.msa_output_dir / "alpha_mmseqs_msa.json").exists()
+
+
 def test_gpu_msa_and_cpu_finalization_stages_run_independently(tmp_path):
     combined = _settings(tmp_path)
     request = FeatureRequest(name="alpha", sequence="ACDE")
     msa_result = MsaBatch(
-        settings=MsaBatchSettings(
-            output_dir=combined.msa_output_dir,
-            temp_dir=combined.temp_dir,
-            unpaired_databases=combined.unpaired_databases,
-            paired_database=combined.paired_database,
-            max_sequences_per_batch=combined.max_sequences_per_batch,
-            max_residues_per_batch=combined.max_residues_per_batch,
-            threads=combined.threads,
-        ),
+        settings=_msa_settings(combined),
         mmseqs_process=FakeMmseqsProcess(),
     ).generate([request])
     summary = tmp_path / "summaries" / "shard.json"
     write_batch_summary(summary, msa_result)
 
     result = FeatureFinalizer(
-        settings=FeatureFinalizationSettings(
-            output_dir=combined.output_dir,
-            msa_input_dir=combined.msa_output_dir,
-            max_template_date=combined.max_template_date,
-            template_seqres_database_id=combined.template_seqres_database_id,
-            template_mmcif_database_id=combined.template_mmcif_database_id,
-        ),
+        settings=_finalization_settings(combined),
         af3_pipeline=PassthroughAf3Pipeline(),
     ).generate([request])
 
+    assert isinstance(msa_result, MsaBatchResult)
+    assert isinstance(msa_result.written[0], MsaArtifact)
     assert json.loads(summary.read_text(encoding="utf-8"))["written"] == ["alpha"]
     assert [artifact.name for artifact in result.written] == ["alpha"]
     assert (combined.output_dir / "alpha_af3_input.json").exists()
+
+
+def test_batch_summary_is_a_content_addressed_artifact_manifest(tmp_path):
+    artifact_path = tmp_path / "alpha_mmseqs_msa.json"
+    artifact_path.write_bytes(b"bundle\n")
+    artifact_stat = artifact_path.stat()
+    summary_path = tmp_path / "summaries" / "shard.json"
+
+    write_batch_summary(
+        summary_path,
+        MsaBatchResult(
+            written=(MsaArtifact(name="alpha", path=artifact_path),),
+            reused=(),
+            failures=(),
+        ),
+    )
+
+    assert json.loads(summary_path.read_text(encoding="utf-8")) == {
+        "schemaVersion": 2,
+        "written": ["alpha"],
+        "reused": [],
+        "artifacts": [
+            {
+                "name": "alpha",
+                "file": "alpha_mmseqs_msa.json",
+                "sizeBytes": 7,
+                "mtimeNs": artifact_stat.st_mtime_ns,
+                "sha256": (
+                    "ef17b7d320f2acc023f2018dab381827ba22f9d01b6c4c97894e1bbfe4928313"
+                ),
+            }
+        ],
+    }
+
+
+def test_deep_stages_accept_only_their_stage_specific_settings(tmp_path):
+    combined = _settings(tmp_path)
+
+    with pytest.raises(TypeError, match="MsaBatchSettings"):
+        MsaBatch(settings=combined, mmseqs_process=FakeMmseqsProcess())
+    with pytest.raises(TypeError, match="FeatureFinalizationSettings"):
+        FeatureFinalizer(settings=combined, af3_pipeline=PassthroughAf3Pipeline())
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        "{",
+        "[]",
+        json.dumps(
+            {
+                "sequence": "WRONG",
+                "provenance": {},
+                "unpairedMsa": ">query\nWRONG\n",
+                "pairedMsa": ">query\nWRONG\n",
+            }
+        ),
+        json.dumps(
+            {
+                "sequence": "ACDE",
+                "unpairedMsa": ">query\nACDE\n",
+                "pairedMsa": ">query\nACDE\n",
+            }
+        ),
+        json.dumps(
+            {
+                "sequence": "ACDE",
+                "provenance": {},
+                "pairedMsa": ">query\nACDE\n",
+            }
+        ),
+    ),
+)
+def test_invalid_msa_bundle_is_removed_so_the_next_dag_can_repair_it(
+    tmp_path, payload
+):
+    combined = _settings(tmp_path)
+    combined.msa_output_dir.mkdir(parents=True)
+    bundle = combined.msa_output_dir / "alpha_mmseqs_msa.json"
+    bundle.write_text(payload, encoding="utf-8")
+
+    result = FeatureFinalizer(
+        settings=_finalization_settings(combined),
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+    assert [failure.name for failure in result.failures] == ["alpha"]
+    assert not bundle.exists()
+
+
+def test_downstream_af3_failure_preserves_a_valid_msa_bundle(tmp_path):
+    combined = _settings(tmp_path)
+    combined.msa_output_dir.mkdir(parents=True)
+    bundle = combined.msa_output_dir / "alpha_mmseqs_msa.json"
+    bundle.write_text(
+        json.dumps(
+            {
+                "sequence": "ACDE",
+                "provenance": {"schema_version": 4},
+                "unpairedMsa": ">query\nACDE\n",
+                "pairedMsa": ">query\nACDE\n",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = FeatureFinalizer(
+        settings=_finalization_settings(combined),
+        af3_pipeline=FailingAf3Pipeline(),
+    ).generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+    assert result.failures[0].error == "fixture template search failure"
+    assert bundle.exists()
 
 
 def test_aligned_fasta_conversion_preserves_taxon_header_and_insertions(tmp_path):
@@ -656,14 +817,16 @@ def test_changed_template_provenance_refinalizes_without_mmseqs_search(
 def test_broken_mmseqs_identity_invalidates_cache_and_reports_useful_failure(tmp_path):
     settings = _settings(tmp_path)
     request = FeatureRequest(name="alpha", sequence="ACDE")
-    MsaBatch(settings=settings, mmseqs_process=FakeMmseqsProcess()).generate([request])
+    MsaBatch(
+        settings=_msa_settings(settings), mmseqs_process=FakeMmseqsProcess()
+    ).generate([request])
 
     class BrokenIdentityProcess:
         def identity(self):
             raise RuntimeError("version command failed")
 
     result = MsaBatch(
-        settings=settings, mmseqs_process=BrokenIdentityProcess()
+        settings=_msa_settings(settings), mmseqs_process=BrokenIdentityProcess()
     ).generate([request])
 
     assert result.reused == ()

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -981,3 +981,11 @@ def test_database_selection_assigns_roles_from_flags():
     selection = database_selection(values)
     assert [db.name for db in selection.unpaired] == list(fb.UNPAIRED_DATABASE_NAMES)
     assert selection.paired.name == fb.PAIRED_DATABASE_NAME
+
+
+def test_cpu_and_gpu_search_are_distinct_cache_identities():
+    """A bundle searched on CPU must not be reused for a GPU run, or vice versa."""
+    from alphapulldown.feature_batch import SubprocessMmseqsProcess
+
+    assert SubprocessMmseqsProcess("/bin/mmseqs", gpu=True).search_mode() == "gpu"
+    assert SubprocessMmseqsProcess("/bin/mmseqs", gpu=False).search_mode() == "cpu"

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -989,3 +989,43 @@ def test_cpu_and_gpu_search_are_distinct_cache_identities():
 
     assert SubprocessMmseqsProcess("/bin/mmseqs", gpu=True).search_mode() == "gpu"
     assert SubprocessMmseqsProcess("/bin/mmseqs", gpu=False).search_mode() == "cpu"
+
+
+def test_split_memory_limit_is_passed_to_the_search(tmp_path: Path):
+    """MMseqs2 otherwise sizes its splits from physical node memory, ignoring the
+    cgroup a batch scheduler applied, and is OOM-killed instead of splitting."""
+    import dataclasses as _dc
+
+    binary = tmp_path / "mmseqs"
+    arguments = Path(f"{binary}.arguments")
+    binary.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "${0}.arguments"\n', encoding="utf-8"
+    )
+    binary.chmod(0o755)
+    database = DatabaseSpec(
+        name="uniref90", path=tmp_path / "uniref90", identifier="fixture"
+    )
+    settings = _dc.replace(_settings(tmp_path), split_memory_limit="150G")
+
+    SubprocessMmseqsProcess(binary).search(
+        tmp_path / "query", database, tmp_path / "result", tmp_path / "work", settings
+    )
+    command = arguments.read_text(encoding="utf-8").splitlines()
+    assert command[command.index("--split-memory-limit") + 1] == "150G"
+
+
+def test_search_omits_the_limit_when_unset(tmp_path: Path):
+    binary = tmp_path / "mmseqs"
+    arguments = Path(f"{binary}.arguments")
+    binary.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "${0}.arguments"\n', encoding="utf-8"
+    )
+    binary.chmod(0o755)
+    database = DatabaseSpec(
+        name="uniref90", path=tmp_path / "uniref90", identifier="fixture"
+    )
+    SubprocessMmseqsProcess(binary).search(
+        tmp_path / "query", database, tmp_path / "result", tmp_path / "work",
+        _settings(tmp_path),
+    )
+    assert "--split-memory-limit" not in arguments.read_text().splitlines()

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -8,9 +8,15 @@ import sys
 
 import pytest
 
-_REAL_FOLDING_INPUT = pytest.importorskip("alphafold3.common.folding_input")
-_REAL_AF3_PIPELINE = pytest.importorskip("alphafold3.data.pipeline")
-_REAL_MSA_CONVERSION = pytest.importorskip("alphafold3.cpp.msa_conversion")
+try:
+    from alphafold3.common import folding_input as _REAL_FOLDING_INPUT
+    from alphafold3.cpp import msa_conversion as _REAL_MSA_CONVERSION
+    from alphafold3.data import pipeline as _REAL_AF3_PIPELINE
+except ImportError as exc:
+    pytest.skip(
+        f"AlphaFold 3 test dependencies are unavailable: {exc}",
+        allow_module_level=True,
+    )
 
 from alphapulldown.feature_batch import (
     DatabaseSpec,

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -22,8 +22,13 @@ from alphapulldown.feature_batch import (
     DatabaseSpec,
     FeatureBatch,
     FeatureBatchSettings,
+    FeatureFinalizationSettings,
+    FeatureFinalizer,
     FeatureRequest,
+    MsaBatch,
+    MsaBatchSettings,
     SubprocessMmseqsProcess,
+    write_batch_summary,
 )
 from alphapulldown.utils.feature_metadata import (
     embed_metadata_in_af3_json,
@@ -64,6 +69,9 @@ class FakeMmseqsProcess:
     def identity(self) -> str:
         self.identity_calls += 1
         return self._identity
+
+    def search_mode(self) -> str:
+        return "gpu"
 
     def create_query_database(self, query_fasta: Path, query_db: Path) -> None:
         records = []
@@ -111,16 +119,31 @@ class FakeMmseqsProcess:
     def unpack_msa(self, query_db: Path, msa_db: Path, output_dir: Path) -> None:
         output_dir.mkdir(parents=True, exist_ok=True)
         database_name = msa_db.read_text(encoding="utf-8")
+        database_index = ("uniref90", "mgnify", "small_bfd", "uniprot").index(
+            database_name
+        )
         for index, (query_id, sequence) in enumerate(self._queries[query_db]):
+            replacement = "VRND"[database_index]
+            hit_sequence = replacement + sequence[1:]
             (output_dir / f"{index}.a3m").write_text(
-                f">{query_id}\n{sequence}\n>{database_name}_hit\n{sequence}\n",
+                f">{query_id}\n{sequence}\n>{database_name}_hit\n{hit_sequence}\n",
                 encoding="utf-8",
             )
+
+
+class MissingUnpackOutputMmseqs(FakeMmseqsProcess):
+    def unpack_msa(self, query_db: Path, msa_db: Path, output_dir: Path) -> None:
+        if msa_db.read_text(encoding="utf-8") == "mgnify":
+            return
+        super().unpack_msa(query_db, msa_db, output_dir)
 
 
 class ForbiddenMmseqsProcess:
     def identity(self) -> str:
         return "mmseqs-fixture-1"
+
+    def search_mode(self) -> str:
+        return "gpu"
 
     def __getattr__(self, operation):
         raise AssertionError(f"cache hit unexpectedly launched MMseqs2: {operation}")
@@ -161,28 +184,31 @@ class PassthroughAf3Pipeline:
         return fold_input
 
 
+class CountingAf3Pipeline(PassthroughAf3Pipeline):
+    def __init__(self):
+        self.calls = 0
+
+    def process(self, fold_input):
+        self.calls += 1
+        return super().process(fold_input)
+
+
 def test_subprocess_adapter_identity_comes_from_mmseqs_version(tmp_path):
     binary = tmp_path / "mmseqs"
     binary.write_text(
-        "#!/bin/sh\n"
-        "test \"$1\" = version\n"
-        "printf 'MMseqs2 Version: gpu-build-18\\n'\n",
+        "#!/bin/sh\ntest \"$1\" = version\nprintf 'MMseqs2 Version: gpu-build-18\\n'\n",
         encoding="utf-8",
     )
     binary.chmod(0o755)
 
-    assert (
-        SubprocessMmseqsProcess(binary).identity()
-        == "MMseqs2 Version: gpu-build-18"
-    )
+    assert SubprocessMmseqsProcess(binary).identity() == "MMseqs2 Version: gpu-build-18"
 
 
 def test_subprocess_adapter_requests_aligned_fasta_output(tmp_path):
     binary = tmp_path / "mmseqs"
     arguments = Path(f"{binary}.arguments")
     binary.write_text(
-        "#!/bin/sh\n"
-        "printf '%s\\n' \"$@\" > \"${0}.arguments\"\n",
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "${0}.arguments"\n',
         encoding="utf-8",
     )
     binary.chmod(0o755)
@@ -200,6 +226,32 @@ def test_subprocess_adapter_requests_aligned_fasta_output(tmp_path):
     command = arguments.read_text(encoding="utf-8").splitlines()
     assert command[0] == "result2msa"
     assert command[command.index("--msa-format-mode") + 1] == "2"
+
+
+def test_gpu_search_does_not_pass_ignored_sensitivity_option(tmp_path):
+    binary = tmp_path / "mmseqs"
+    arguments = Path(f"{binary}.arguments")
+    binary.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "${0}.arguments"\n',
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    database = DatabaseSpec(
+        name="uniref90", path=tmp_path / "uniref90", identifier="fixture"
+    )
+
+    SubprocessMmseqsProcess(binary).search(
+        tmp_path / "query",
+        database,
+        tmp_path / "result",
+        tmp_path / "work",
+        _settings(tmp_path),
+    )
+
+    command = arguments.read_text(encoding="utf-8").splitlines()
+    assert "-s" not in command
+    assert command[command.index("--max-seqs") + 1] == "10000"
+    assert command[command.index("--gpu") + 1] == "1"
 
 
 def _native_pipeline_with_no_template_hits(tmp_path: Path):
@@ -257,12 +309,16 @@ def _settings(tmp_path: Path) -> FeatureBatchSettings:
         specs.append(DatabaseSpec(name=name, path=path, identifier=f"{name}-2026"))
     return FeatureBatchSettings(
         output_dir=tmp_path / "features",
+        msa_output_dir=tmp_path / "msas",
         temp_dir=tmp_path / "scratch",
         unpaired_databases=tuple(specs[:3]),
         paired_database=specs[3],
         max_sequences_per_batch=8,
         max_residues_per_batch=1_000,
         threads=4,
+        max_template_date="2050-01-01",
+        template_seqres_database_id="pdb-seqres-2050",
+        template_mmcif_database_id="mmcif-2050",
     )
 
 
@@ -292,8 +348,59 @@ def test_duplicate_sequences_are_searched_once_and_create_standard_artifacts(tmp
         protein = payload["sequences"][0]["protein"]
         assert protein["sequence"] == "ACDEFG"
         assert protein["unpairedMsa"].count(">query") == 1
+        assert ">uniref90_hit" in protein["unpairedMsa"]
+        assert ">mgnify_hit" in protein["unpairedMsa"]
+        assert ">small_bfd_hit" in protein["unpairedMsa"]
         assert ">uniprot_hit" in protein["pairedMsa"]
         assert protein["templates"] == []
+
+
+def test_missing_unpack_output_fails_instead_of_caching_query_only_msa(tmp_path):
+    settings = _settings(tmp_path)
+
+    result = MsaBatch(
+        settings=settings,
+        mmseqs_process=MissingUnpackOutputMmseqs(),
+    ).generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+    assert result.written == ()
+    assert [failure.name for failure in result.failures] == ["alpha"]
+    assert "mgnify" in result.failures[0].error
+    assert not (settings.msa_output_dir / "alpha_mmseqs_msa.json").exists()
+
+
+def test_gpu_msa_and_cpu_finalization_stages_run_independently(tmp_path):
+    combined = _settings(tmp_path)
+    request = FeatureRequest(name="alpha", sequence="ACDE")
+    msa_result = MsaBatch(
+        settings=MsaBatchSettings(
+            output_dir=combined.msa_output_dir,
+            temp_dir=combined.temp_dir,
+            unpaired_databases=combined.unpaired_databases,
+            paired_database=combined.paired_database,
+            max_sequences_per_batch=combined.max_sequences_per_batch,
+            max_residues_per_batch=combined.max_residues_per_batch,
+            threads=combined.threads,
+        ),
+        mmseqs_process=FakeMmseqsProcess(),
+    ).generate([request])
+    summary = tmp_path / "summaries" / "shard.json"
+    write_batch_summary(summary, msa_result)
+
+    result = FeatureFinalizer(
+        settings=FeatureFinalizationSettings(
+            output_dir=combined.output_dir,
+            msa_input_dir=combined.msa_output_dir,
+            max_template_date=combined.max_template_date,
+            template_seqres_database_id=combined.template_seqres_database_id,
+            template_mmcif_database_id=combined.template_mmcif_database_id,
+        ),
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+
+    assert json.loads(summary.read_text(encoding="utf-8"))["written"] == ["alpha"]
+    assert [artifact.name for artifact in result.written] == ["alpha"]
+    assert (combined.output_dir / "alpha_af3_input.json").exists()
 
 
 def test_aligned_fasta_conversion_preserves_taxon_header_and_insertions(tmp_path):
@@ -307,9 +414,7 @@ def test_aligned_fasta_conversion_preserves_taxon_header_and_insertions(tmp_path
 
     assert result.failures == ()
     payload = json.loads(
-        (tmp_path / "features" / "alpha_af3_input.json").read_text(
-            encoding="utf-8"
-        )
+        (tmp_path / "features" / "alpha_af3_input.json").read_text(encoding="utf-8")
     )
     paired_msa = payload["sequences"][0]["protein"]["pairedMsa"]
     assert (
@@ -385,9 +490,7 @@ def test_all_native_af3_msa_databases_must_be_explicit(tmp_path):
 
 def test_database_paths_and_identifiers_must_be_explicit(tmp_path):
     settings = _settings(tmp_path)
-    missing_path = dataclasses.replace(
-        settings.unpaired_databases[0], path=Path("")
-    )
+    missing_path = dataclasses.replace(settings.unpaired_databases[0], path=Path(""))
     settings = dataclasses.replace(
         settings,
         unpaired_databases=(missing_path, *settings.unpaired_databases[1:]),
@@ -422,12 +525,10 @@ def test_database_paths_and_identifiers_must_be_explicit(tmp_path):
 
 @pytest.mark.parametrize(
     ("field", "value"),
-    (("threads", 0), ("sensitivity", 0), ("e_value", 0)),
+    (("threads", 0), ("e_value", 0)),
 )
 def test_search_settings_are_validated_before_process_launch(tmp_path, field, value):
-    settings = dataclasses.replace(
-        _settings(tmp_path), **{field: value}
-    )
+    settings = dataclasses.replace(_settings(tmp_path), **{field: value})
     batch = FeatureBatch(
         settings=settings,
         mmseqs_process=ForbiddenMmseqsProcess(),
@@ -482,9 +583,7 @@ def test_changed_database_identifier_regenerates_cached_sequence(tmp_path):
     changed_database = dataclasses.replace(
         settings.paired_database, identifier="uniprot-2027"
     )
-    changed_settings = dataclasses.replace(
-        settings, paired_database=changed_database
-    )
+    changed_settings = dataclasses.replace(settings, paired_database=changed_database)
     process = FakeMmseqsProcess()
 
     second = FeatureBatch(
@@ -522,7 +621,59 @@ def test_changed_mmseqs_identity_regenerates_cached_sequence(tmp_path):
     assert second_process.identity_calls == 1
 
 
-def test_legacy_alignment_schema_regenerates_cached_sequence(tmp_path):
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("max_template_date", "2051-01-01"),
+        ("template_seqres_database_id", "pdb-seqres-2051"),
+        ("template_mmcif_database_id", "mmcif-2051"),
+    ),
+)
+def test_changed_template_provenance_refinalizes_without_mmseqs_search(
+    tmp_path, field, value
+):
+    settings = _settings(tmp_path)
+    request = FeatureRequest(name="alpha", sequence="ACDE")
+    FeatureBatch(
+        settings=settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+    changed_settings = dataclasses.replace(settings, **{field: value})
+    pipeline = CountingAf3Pipeline()
+
+    result = FeatureBatch(
+        settings=changed_settings,
+        mmseqs_process=ForbiddenMmseqsProcess(),
+        af3_pipeline=pipeline,
+    ).generate([request])
+
+    assert result.reused == ()
+    assert [artifact.name for artifact in result.written] == ["alpha"]
+    assert pipeline.calls == 1
+
+
+def test_broken_mmseqs_identity_invalidates_cache_and_reports_useful_failure(tmp_path):
+    settings = _settings(tmp_path)
+    request = FeatureRequest(name="alpha", sequence="ACDE")
+    MsaBatch(settings=settings, mmseqs_process=FakeMmseqsProcess()).generate([request])
+
+    class BrokenIdentityProcess:
+        def identity(self):
+            raise RuntimeError("version command failed")
+
+    result = MsaBatch(
+        settings=settings, mmseqs_process=BrokenIdentityProcess()
+    ).generate([request])
+
+    assert result.reused == ()
+    assert [failure.name for failure in result.failures] == ["alpha"]
+    assert (
+        "Cannot identify the configured MMseqs2 executable" in result.failures[0].error
+    )
+
+
+def test_stale_final_artifact_reuses_valid_msa_and_only_refinalizes(tmp_path):
     settings = _settings(tmp_path)
     request = FeatureRequest(name="alpha", sequence="ACDE")
     FeatureBatch(
@@ -548,7 +699,7 @@ def test_legacy_alignment_schema_regenerates_cached_sequence(tmp_path):
 
     assert result.reused == ()
     assert [item.name for item in result.written] == ["alpha"]
-    assert len(process._queries) == 1
+    assert len(process._queries) == 0
 
 
 def test_cached_sequence_supplies_another_name_without_external_search(tmp_path):

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import lzma
+from pathlib import Path
+import sys
+
+import pytest
+
+_REAL_FOLDING_INPUT = pytest.importorskip("alphafold3.common.folding_input")
+_REAL_AF3_PIPELINE = pytest.importorskip("alphafold3.data.pipeline")
+
+from alphapulldown.feature_batch import (
+    DatabaseSpec,
+    FeatureBatch,
+    FeatureBatchSettings,
+    FeatureRequest,
+)
+
+
+@pytest.fixture(autouse=True)
+def _use_real_af3_modules(monkeypatch):
+    """Insulate these integration tests from another module's AF3 stubs."""
+    common_package = sys.modules["alphafold3.common"]
+    data_package = sys.modules["alphafold3.data"]
+    monkeypatch.setitem(
+        sys.modules, "alphafold3.common.folding_input", _REAL_FOLDING_INPUT
+    )
+    monkeypatch.setitem(sys.modules, "alphafold3.data.pipeline", _REAL_AF3_PIPELINE)
+    monkeypatch.setattr(
+        common_package, "folding_input", _REAL_FOLDING_INPUT, raising=False
+    )
+    monkeypatch.setattr(data_package, "pipeline", _REAL_AF3_PIPELINE, raising=False)
+
+
+class FakeMmseqsProcess:
+    """Deterministic stand-in for the external MMseqs2 process."""
+
+    def __init__(self) -> None:
+        self._queries: dict[Path, list[tuple[str, str]]] = {}
+
+    def create_query_database(self, query_fasta: Path, query_db: Path) -> None:
+        records = []
+        description = None
+        sequence_parts = []
+        for line in query_fasta.read_text(encoding="utf-8").splitlines():
+            if line.startswith(">"):
+                if description is not None:
+                    records.append((description, "".join(sequence_parts)))
+                description = line[1:]
+                sequence_parts = []
+            else:
+                sequence_parts.append(line.strip())
+        if description is not None:
+            records.append((description, "".join(sequence_parts)))
+
+        assert len({sequence for _, sequence in records}) == len(records)
+        self._queries[query_db] = records
+        Path(f"{query_db}.lookup").write_text(
+            "".join(f"{index}\t{name}\t0\n" for index, (name, _) in enumerate(records)),
+            encoding="utf-8",
+        )
+
+    def search(
+        self,
+        query_db: Path,
+        database: DatabaseSpec,
+        result_db: Path,
+        work_dir: Path,
+        settings: FeatureBatchSettings,
+    ) -> None:
+        del query_db, work_dir, settings
+        result_db.write_text(database.name, encoding="utf-8")
+
+    def result_to_msa(
+        self,
+        query_db: Path,
+        database: DatabaseSpec,
+        result_db: Path,
+        msa_db: Path,
+    ) -> None:
+        del query_db, result_db
+        msa_db.write_text(database.name, encoding="utf-8")
+
+    def unpack_msa(self, query_db: Path, msa_db: Path, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        database_name = msa_db.read_text(encoding="utf-8")
+        for index, (query_id, sequence) in enumerate(self._queries[query_db]):
+            (output_dir / f"{index}.a3m").write_text(
+                f">{query_id}\n{sequence}\n>{database_name}_hit\n{sequence}\n",
+                encoding="utf-8",
+            )
+
+
+class ForbiddenMmseqsProcess:
+    def __getattr__(self, operation):
+        raise AssertionError(f"cache hit unexpectedly launched MMseqs2: {operation}")
+
+
+class FirstSequenceFailsMmseqs(FakeMmseqsProcess):
+    def search(
+        self,
+        query_db: Path,
+        database: DatabaseSpec,
+        result_db: Path,
+        work_dir: Path,
+        settings: FeatureBatchSettings,
+    ) -> None:
+        if self._queries[query_db][0][1] == "ACDE":
+            raise RuntimeError("fixture MMseqs2 failure")
+        super().search(query_db, database, result_db, work_dir, settings)
+
+
+class PassthroughAf3Pipeline:
+    def process(self, fold_input):
+        return fold_input
+
+
+def _native_pipeline_with_no_template_hits(tmp_path: Path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    hmmbuild = bin_dir / "hmmbuild"
+    hmmbuild.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib, sys\n"
+        "pathlib.Path(sys.argv[-2]).write_text('HMM\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    hmmsearch = bin_dir / "hmmsearch"
+    hmmsearch.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib, sys\n"
+        "pathlib.Path(sys.argv[sys.argv.index('-A') + 1]).write_text('', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    hmmbuild.chmod(0o755)
+    hmmsearch.chmod(0o755)
+
+    sequence_database = tmp_path / "pdb_seqres.fasta"
+    sequence_database.write_text(">none\nAAAA\n", encoding="utf-8")
+    structure_directory = tmp_path / "mmcif"
+    structure_directory.mkdir()
+
+    config = _REAL_AF3_PIPELINE.DataPipelineConfig(
+        jackhmmer_binary_path=str(hmmbuild),
+        nhmmer_binary_path=str(hmmbuild),
+        hmmalign_binary_path=str(hmmbuild),
+        hmmsearch_binary_path=str(hmmsearch),
+        hmmbuild_binary_path=str(hmmbuild),
+        small_bfd_database_path=str(sequence_database),
+        mgnify_database_path=str(sequence_database),
+        uniprot_cluster_annot_database_path=str(sequence_database),
+        uniref90_database_path=str(sequence_database),
+        ntrna_database_path=str(sequence_database),
+        rfam_database_path=str(sequence_database),
+        rna_central_database_path=str(sequence_database),
+        seqres_database_path=str(sequence_database),
+        pdb_database_path=str(structure_directory),
+        max_template_date=__import__("datetime").date(2050, 1, 1),
+    )
+    return _REAL_AF3_PIPELINE.DataPipeline(config)
+
+
+def _settings(tmp_path: Path) -> FeatureBatchSettings:
+    databases = tmp_path / "databases"
+    databases.mkdir()
+    specs = []
+    for name in ("uniref90", "mgnify", "small_bfd", "uniprot"):
+        path = databases / name
+        path.write_text("fixture", encoding="utf-8")
+        specs.append(DatabaseSpec(name=name, path=path, identifier=f"{name}-2026"))
+    return FeatureBatchSettings(
+        output_dir=tmp_path / "features",
+        temp_dir=tmp_path / "scratch",
+        unpaired_databases=tuple(specs[:3]),
+        paired_database=specs[3],
+        max_sequences_per_batch=8,
+        max_residues_per_batch=1_000,
+        threads=4,
+    )
+
+
+def test_duplicate_sequences_are_searched_once_and_create_standard_artifacts(tmp_path):
+    batch = FeatureBatch(
+        settings=_settings(tmp_path),
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=_native_pipeline_with_no_template_hits(tmp_path),
+    )
+
+    result = batch.generate(
+        [
+            FeatureRequest(name="alpha", sequence="ACDEFG"),
+            FeatureRequest(name="beta", sequence="ACDEFG"),
+        ]
+    )
+
+    assert result.failures == ()
+    assert [artifact.name for artifact in result.written] == ["alpha", "beta"]
+    for name in ("alpha", "beta"):
+        payload = json.loads(
+            (tmp_path / "features" / f"{name}_af3_input.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert payload["name"] == name
+        protein = payload["sequences"][0]["protein"]
+        assert protein["sequence"] == "ACDEFG"
+        assert protein["unpairedMsa"].count(">query") == 1
+        assert ">uniprot_hit" in protein["pairedMsa"]
+        assert protein["templates"] == []
+
+
+def test_matching_artifact_is_reused_without_external_search(tmp_path):
+    settings = _settings(tmp_path)
+    pipeline = _native_pipeline_with_no_template_hits(tmp_path)
+    request = FeatureRequest(name="alpha", sequence="ACDEFG")
+    first = FeatureBatch(
+        settings=settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=pipeline,
+    ).generate([request])
+    assert [artifact.name for artifact in first.written] == ["alpha"]
+
+    second = FeatureBatch(
+        settings=settings,
+        mmseqs_process=ForbiddenMmseqsProcess(),
+        af3_pipeline=pipeline,
+    ).generate([request])
+
+    assert second.failures == ()
+    assert second.written == ()
+    assert [artifact.name for artifact in second.reused] == ["alpha"]
+
+
+def test_failed_chunk_is_reported_while_later_chunks_complete(tmp_path):
+    settings = _settings(tmp_path)
+    settings = dataclasses.replace(settings, max_sequences_per_batch=1)
+    batch = FeatureBatch(
+        settings=settings,
+        mmseqs_process=FirstSequenceFailsMmseqs(),
+        af3_pipeline=_native_pipeline_with_no_template_hits(tmp_path),
+    )
+
+    result = batch.generate(
+        [
+            FeatureRequest(name="alpha", sequence="ACDE"),
+            FeatureRequest(name="beta", sequence="FGHIK"),
+        ]
+    )
+
+    assert [(failure.name, failure.error) for failure in result.failures] == [
+        ("alpha", "fixture MMseqs2 failure")
+    ]
+    assert [artifact.name for artifact in result.written] == ["beta"]
+    assert not (tmp_path / "features" / "alpha_af3_input.json").exists()
+    assert (tmp_path / "features" / "beta_af3_input.json").exists()
+
+
+def test_all_native_af3_msa_databases_must_be_explicit(tmp_path):
+    settings = _settings(tmp_path)
+    settings = dataclasses.replace(
+        settings, unpaired_databases=settings.unpaired_databases[:2]
+    )
+    batch = FeatureBatch(
+        settings=settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=_native_pipeline_with_no_template_hits(tmp_path),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="uniref90, mgnify, and small_bfd",
+    ):
+        batch.generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+
+def test_database_paths_and_identifiers_must_be_explicit(tmp_path):
+    settings = _settings(tmp_path)
+    missing_path = dataclasses.replace(
+        settings.unpaired_databases[0], path=Path("")
+    )
+    settings = dataclasses.replace(
+        settings,
+        unpaired_databases=(missing_path, *settings.unpaired_databases[1:]),
+    )
+    batch = FeatureBatch(
+        settings=settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=_native_pipeline_with_no_template_hits(tmp_path),
+    )
+
+    with pytest.raises(ValueError, match="path"):
+        batch.generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+    identifier_case = tmp_path / "identifier_case"
+    identifier_case.mkdir()
+    identifier_settings = _settings(identifier_case)
+    blank_identifier = dataclasses.replace(
+        identifier_settings.paired_database, identifier=" "
+    )
+    identifier_settings = dataclasses.replace(
+        identifier_settings, paired_database=blank_identifier
+    )
+    identifier_batch = FeatureBatch(
+        settings=identifier_settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=_native_pipeline_with_no_template_hits(identifier_case),
+    )
+
+    with pytest.raises(ValueError, match="identifier"):
+        identifier_batch.generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("threads", 0), ("sensitivity", 0), ("e_value", 0)),
+)
+def test_search_settings_are_validated_before_process_launch(tmp_path, field, value):
+    settings = dataclasses.replace(
+        _settings(tmp_path), **{field: value}
+    )
+    batch = FeatureBatch(
+        settings=settings,
+        mmseqs_process=ForbiddenMmseqsProcess(),
+        af3_pipeline=object(),
+    )
+
+    with pytest.raises(ValueError, match=field):
+        batch.generate([FeatureRequest(name="alpha", sequence="ACDE")])
+
+
+def test_residue_limit_chunks_unique_sequences_and_keeps_oversized_query_alone(
+    tmp_path,
+):
+    settings = dataclasses.replace(
+        _settings(tmp_path),
+        max_sequences_per_batch=10,
+        max_residues_per_batch=6,
+    )
+    process = FakeMmseqsProcess()
+    batch = FeatureBatch(
+        settings=settings,
+        mmseqs_process=process,
+        af3_pipeline=PassthroughAf3Pipeline(),
+    )
+
+    result = batch.generate(
+        [
+            FeatureRequest(name="alpha", sequence="ACDE"),
+            FeatureRequest(name="beta", sequence="FGH"),
+            FeatureRequest(name="gamma", sequence="IK"),
+            FeatureRequest(name="delta", sequence="LMNPQRS"),
+        ]
+    )
+
+    assert result.failures == ()
+    assert [
+        tuple(sequence for _, sequence in records)
+        for records in process._queries.values()
+    ] == [("ACDE",), ("FGH", "IK"), ("LMNPQRS",)]
+
+
+def test_changed_database_identifier_regenerates_cached_sequence(tmp_path):
+    settings = _settings(tmp_path)
+    request = FeatureRequest(name="alpha", sequence="ACDE")
+    first = FeatureBatch(
+        settings=settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+    assert [artifact.name for artifact in first.written] == ["alpha"]
+
+    changed_database = dataclasses.replace(
+        settings.paired_database, identifier="uniprot-2027"
+    )
+    changed_settings = dataclasses.replace(
+        settings, paired_database=changed_database
+    )
+    process = FakeMmseqsProcess()
+
+    second = FeatureBatch(
+        settings=changed_settings,
+        mmseqs_process=process,
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+
+    assert second.reused == ()
+    assert [artifact.name for artifact in second.written] == ["alpha"]
+    assert len(process._queries) == 1
+
+
+def test_cached_sequence_supplies_another_name_without_external_search(tmp_path):
+    settings = _settings(tmp_path)
+    pipeline = PassthroughAf3Pipeline()
+    alpha = FeatureRequest(name="alpha", sequence="ACDE")
+    FeatureBatch(
+        settings=settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=pipeline,
+    ).generate([alpha])
+
+    result = FeatureBatch(
+        settings=settings,
+        mmseqs_process=ForbiddenMmseqsProcess(),
+        af3_pipeline=pipeline,
+    ).generate([alpha, FeatureRequest(name="alias", sequence="ACDE")])
+
+    assert [artifact.name for artifact in result.reused] == ["alpha"]
+    assert [artifact.name for artifact in result.written] == ["alias"]
+    assert result.failures == ()
+
+
+def test_compressed_artifact_uses_existing_af3_filename_and_is_cacheable(tmp_path):
+    settings = dataclasses.replace(_settings(tmp_path), compress=True)
+    request = FeatureRequest(name="alpha", sequence="ACDE")
+    FeatureBatch(
+        settings=settings,
+        mmseqs_process=FakeMmseqsProcess(),
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+
+    artifact = tmp_path / "features" / "alpha_af3_input.json.xz"
+    with lzma.open(artifact, "rt", encoding="utf-8") as handle:
+        assert json.load(handle)["sequences"][0]["protein"]["sequence"] == "ACDE"
+
+    reused = FeatureBatch(
+        settings=settings,
+        mmseqs_process=ForbiddenMmseqsProcess(),
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+    assert [item.path for item in reused.reused] == [artifact]

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -16,6 +16,7 @@ from alphapulldown.feature_batch import (
     FeatureBatch,
     FeatureBatchSettings,
     FeatureRequest,
+    SubprocessMmseqsProcess,
 )
 
 
@@ -37,8 +38,14 @@ def _use_real_af3_modules(monkeypatch):
 class FakeMmseqsProcess:
     """Deterministic stand-in for the external MMseqs2 process."""
 
-    def __init__(self) -> None:
+    def __init__(self, identity: str = "mmseqs-fixture-1") -> None:
+        self._identity = identity
+        self.identity_calls = 0
         self._queries: dict[Path, list[tuple[str, str]]] = {}
+
+    def identity(self) -> str:
+        self.identity_calls += 1
+        return self._identity
 
     def create_query_database(self, query_fasta: Path, query_db: Path) -> None:
         records = []
@@ -94,6 +101,9 @@ class FakeMmseqsProcess:
 
 
 class ForbiddenMmseqsProcess:
+    def identity(self) -> str:
+        return "mmseqs-fixture-1"
+
     def __getattr__(self, operation):
         raise AssertionError(f"cache hit unexpectedly launched MMseqs2: {operation}")
 
@@ -115,6 +125,22 @@ class FirstSequenceFailsMmseqs(FakeMmseqsProcess):
 class PassthroughAf3Pipeline:
     def process(self, fold_input):
         return fold_input
+
+
+def test_subprocess_adapter_identity_comes_from_mmseqs_version(tmp_path):
+    binary = tmp_path / "mmseqs"
+    binary.write_text(
+        "#!/bin/sh\n"
+        "test \"$1\" = version\n"
+        "printf 'MMseqs2 Version: gpu-build-18\\n'\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+
+    assert (
+        SubprocessMmseqsProcess(binary).identity()
+        == "MMseqs2 Version: gpu-build-18"
+    )
 
 
 def _native_pipeline_with_no_template_hits(tmp_path: Path):
@@ -388,6 +414,30 @@ def test_changed_database_identifier_regenerates_cached_sequence(tmp_path):
     assert second.reused == ()
     assert [artifact.name for artifact in second.written] == ["alpha"]
     assert len(process._queries) == 1
+
+
+def test_changed_mmseqs_identity_regenerates_cached_sequence(tmp_path):
+    settings = _settings(tmp_path)
+    request = FeatureRequest(name="alpha", sequence="ACDE")
+    first_process = FakeMmseqsProcess(identity="mmseqs-gpu-17")
+    first = FeatureBatch(
+        settings=settings,
+        mmseqs_process=first_process,
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+    assert [artifact.name for artifact in first.written] == ["alpha"]
+
+    second_process = FakeMmseqsProcess(identity="mmseqs-gpu-18")
+    second = FeatureBatch(
+        settings=settings,
+        mmseqs_process=second_process,
+        af3_pipeline=PassthroughAf3Pipeline(),
+    ).generate([request])
+
+    assert second.reused == ()
+    assert [artifact.name for artifact in second.written] == ["alpha"]
+    assert len(second_process._queries) == 1
+    assert second_process.identity_calls == 1
 
 
 def test_cached_sequence_supplies_another_name_without_external_search(tmp_path):

--- a/test/unit/test_feature_batch.py
+++ b/test/unit/test_feature_batch.py
@@ -30,6 +30,7 @@ from alphapulldown.feature_batch import (
     MsaBatchResult,
     MsaBatchSettings,
     SubprocessMmseqsProcess,
+    _normalise_query,
     write_batch_summary,
 )
 from alphapulldown.utils.feature_metadata import (
@@ -427,6 +428,11 @@ def test_empty_unpack_output_fails_instead_of_caching_query_only_msa(tmp_path):
     assert "mgnify" in result.failures[0].error
     assert "no FASTA records" in result.failures[0].error
     assert not (settings.msa_output_dir / "alpha_mmseqs_msa.json").exists()
+
+
+def test_normalise_query_rejects_an_empty_alignment():
+    with pytest.raises(ValueError, match="contains no records"):
+        _normalise_query("", "ACDE")
 
 
 def test_gpu_msa_and_cpu_finalization_stages_run_independently(tmp_path):

--- a/test/unit/test_mmseqs2_gpu_dockerfiles.py
+++ b/test/unit/test_mmseqs2_gpu_dockerfiles.py
@@ -95,3 +95,6 @@ def test_alphafold3_pr_build_runs_compiled_feature_batch_contracts():
     )
     assert "test/unit/test_feature_batch.py" in dockerfile
     assert "test/unit/test_create_batch_features.py" in dockerfile
+    assert "MMSEQS_INTEGRATION_BINARY=/opt/mmseqs/bin/mmseqs" in dockerfile
+    assert "test/integration/test_mmseqs2_command_contract.py" in dockerfile
+    assert 'addopts="-ra --strict-markers"' in dockerfile

--- a/test/unit/test_mmseqs2_gpu_dockerfiles.py
+++ b/test/unit/test_mmseqs2_gpu_dockerfiles.py
@@ -36,10 +36,7 @@ def test_prediction_images_install_the_same_verified_mmseqs2_gpu_release(dockerf
         "${MMSEQS_VERSION}/mmseqs-linux-gpu.tar.gz"
     ) in source
     assert "sha256sum -c -" in source
-    assert (
-        'test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_COMMIT}"'
-        in source
-    )
+    assert 'test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_COMMIT}"' in source
 
 
 def test_alphafold2_container_builds_on_pull_requests_without_secrets():
@@ -77,3 +74,24 @@ def test_alphafold2_container_builds_on_pull_requests_without_secrets():
         "github.event_name == 'release' && github.event.action == 'published'",
     }
     assert all(step["with"]["ssh"] == "default" for step in publish_steps)
+
+
+def test_alphafold3_pr_build_runs_compiled_feature_batch_contracts():
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["build-alphafold3-container"]["steps"]
+    pull_request_build = next(
+        step
+        for step in steps
+        if step.get("name")
+        == "Build alphafold3 container and run compiled-AF3 compatibility tests"
+    )
+    assert pull_request_build["if"] == "github.event_name == 'pull_request'"
+    assert pull_request_build["with"]["context"] == "."
+    assert pull_request_build["with"]["file"] == "./docker/alphafold3.dockerfile"
+    assert pull_request_build["with"]["push"] == "false"
+
+    dockerfile = (REPOSITORY / "docker" / "alphafold3.dockerfile").read_text(
+        encoding="utf-8"
+    )
+    assert "test/unit/test_feature_batch.py" in dockerfile
+    assert "test/unit/test_create_batch_features.py" in dockerfile

--- a/test/unit/test_mmseqs2_gpu_dockerfiles.py
+++ b/test/unit/test_mmseqs2_gpu_dockerfiles.py
@@ -54,7 +54,10 @@ def test_alphafold2_container_builds_on_pull_requests_without_secrets():
         if step.get("uses", "").startswith("docker/login-action@")
     )
     pull_request_build = next(
-        step for step in steps if step.get("name") == "Build alphafold2 container"
+        step
+        for step in steps
+        if step.get("name", "").startswith("Build alphafold2 container")
+        and "push" not in step.get("name", "")
     )
 
     assert ssh_agent["if"] == "github.event_name != 'pull_request'"

--- a/test/unit/test_mmseqs2_gpu_dockerfiles.py
+++ b/test/unit/test_mmseqs2_gpu_dockerfiles.py
@@ -12,6 +12,7 @@ DOCKERFILES = (
     REPOSITORY / "docker" / "alphafold3.dockerfile",
 )
 EXPECTED_VERSION = "18-8cc5c"
+EXPECTED_COMMIT = "8cc5ce367b5638c4306c2d7cfc652dd099a4643f"
 EXPECTED_SHA256 = "83969dd5c7d4c32858c2fc9a4d1024c15e8fe5da768ce76e787ab0195ffd64e7"
 
 
@@ -26,10 +27,14 @@ def test_prediction_images_install_the_same_verified_mmseqs2_gpu_release(dockerf
     source = dockerfile.read_text(encoding="utf-8")
 
     assert _build_argument(source, "MMSEQS_VERSION") == EXPECTED_VERSION
+    assert _build_argument(source, "MMSEQS_COMMIT") == EXPECTED_COMMIT
     assert _build_argument(source, "MMSEQS_GPU_SHA256") == EXPECTED_SHA256
     assert (
         "https://github.com/soedinglab/MMseqs2/releases/download/"
         "${MMSEQS_VERSION}/mmseqs-linux-gpu.tar.gz"
     ) in source
     assert "sha256sum -c -" in source
-    assert "/opt/mmseqs/bin/mmseqs version" in source
+    assert (
+        'test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_COMMIT}"'
+        in source
+    )

--- a/test/unit/test_mmseqs2_gpu_dockerfiles.py
+++ b/test/unit/test_mmseqs2_gpu_dockerfiles.py
@@ -1,0 +1,35 @@
+"""Build contracts for the MMseqs2-GPU runtime shared by both images."""
+
+from pathlib import Path
+import re
+
+import pytest
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+DOCKERFILES = (
+    REPOSITORY / "docker" / "alphafold2.dockerfile",
+    REPOSITORY / "docker" / "alphafold3.dockerfile",
+)
+EXPECTED_VERSION = "18-8cc5c"
+EXPECTED_SHA256 = "83969dd5c7d4c32858c2fc9a4d1024c15e8fe5da768ce76e787ab0195ffd64e7"
+
+
+def _build_argument(source: str, name: str) -> str:
+    match = re.search(rf"^ARG {name}=([^\s]+)$", source, flags=re.MULTILINE)
+    assert match is not None, f"missing {name} build pin"
+    return match.group(1)
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES)
+def test_prediction_images_install_the_same_verified_mmseqs2_gpu_release(dockerfile):
+    source = dockerfile.read_text(encoding="utf-8")
+
+    assert _build_argument(source, "MMSEQS_VERSION") == EXPECTED_VERSION
+    assert _build_argument(source, "MMSEQS_GPU_SHA256") == EXPECTED_SHA256
+    assert (
+        "https://github.com/soedinglab/MMseqs2/releases/download/"
+        "${MMSEQS_VERSION}/mmseqs-linux-gpu.tar.gz"
+    ) in source
+    assert "sha256sum -c -" in source
+    assert "/opt/mmseqs/bin/mmseqs version" in source

--- a/test/unit/test_mmseqs2_gpu_dockerfiles.py
+++ b/test/unit/test_mmseqs2_gpu_dockerfiles.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 
 import pytest
+import yaml
 
 
 REPOSITORY = Path(__file__).resolve().parents[2]
@@ -14,6 +15,7 @@ DOCKERFILES = (
 EXPECTED_VERSION = "18-8cc5c"
 EXPECTED_COMMIT = "8cc5ce367b5638c4306c2d7cfc652dd099a4643f"
 EXPECTED_SHA256 = "83969dd5c7d4c32858c2fc9a4d1024c15e8fe5da768ce76e787ab0195ffd64e7"
+WORKFLOW = REPOSITORY / ".github" / "workflows" / "github_actions.yml"
 
 
 def _build_argument(source: str, name: str) -> str:
@@ -38,3 +40,40 @@ def test_prediction_images_install_the_same_verified_mmseqs2_gpu_release(dockerf
         'test "$(/opt/mmseqs/bin/mmseqs version)" = "${MMSEQS_COMMIT}"'
         in source
     )
+
+
+def test_alphafold2_container_builds_on_pull_requests_without_secrets():
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["build-alphafold2-container"]["steps"]
+
+    ssh_agent = next(
+        step
+        for step in steps
+        if step.get("uses", "").startswith("webfactory/ssh-agent@")
+    )
+    registry_login = next(
+        step
+        for step in steps
+        if step.get("uses", "").startswith("docker/login-action@")
+    )
+    pull_request_build = next(
+        step for step in steps if step.get("name") == "Build alphafold2 container"
+    )
+
+    assert ssh_agent["if"] == "github.event_name != 'pull_request'"
+    assert registry_login["if"] == "github.event_name != 'pull_request'"
+    assert pull_request_build["if"] == "github.event_name == 'pull_request'"
+    assert pull_request_build["uses"].startswith("docker/build-push-action@")
+    assert pull_request_build["with"]["context"] == "."
+    assert pull_request_build["with"]["file"] == "./docker/alphafold2.dockerfile"
+    assert pull_request_build["with"]["push"] == "false"
+    assert "ssh" not in pull_request_build["with"]
+
+    publish_steps = [
+        step for step in steps if step.get("with", {}).get("push") == "true"
+    ]
+    assert {step["if"] for step in publish_steps} == {
+        "github.event_name == 'push'",
+        "github.event_name == 'release' && github.event.action == 'published'",
+    }
+    assert all(step["with"]["ssh"] == "default" for step in publish_steps)

--- a/test/unit/test_msa_quality.py
+++ b/test/unit/test_msa_quality.py
@@ -1,0 +1,68 @@
+import json
+
+import pytest
+
+from alphapulldown.scripts.compare_msa_backends import compare_directories
+from alphapulldown.utils.msa_quality import measure_a3m
+
+
+def test_measure_a3m_reports_depth_uniqueness_and_query_coverage():
+    metrics = measure_a3m(
+        ">query\nACDE\n>full\nACDE\n>partial\nA--E\n>duplicate\nA--E\n",
+        query_length=4,
+    )
+
+    assert metrics == {
+        "depth": 4,
+        "unique_depth": 2,
+        "mean_non_gap_coverage": 0.75,
+    }
+
+
+def _feature(path, *, sequence="ACDE", unpaired=">query\nACDE\n"):
+    path.write_text(
+        json.dumps(
+            {
+                "sequences": [
+                    {
+                        "protein": {
+                            "sequence": sequence,
+                            "unpairedMsa": unpaired,
+                            "pairedMsa": ">query\nACDE\n",
+                            "templates": [],
+                        }
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_compare_directories_pairs_every_artifact_and_reports_depth(tmp_path):
+    reference = tmp_path / "reference"
+    candidate = tmp_path / "candidate"
+    reference.mkdir()
+    candidate.mkdir()
+    _feature(reference / "alpha_af3_input.json")
+    _feature(
+        candidate / "alpha_af3_input.json",
+        unpaired=">query\nACDE\n>hit\nAC-E\n",
+    )
+
+    rows = compare_directories(reference, candidate)
+
+    assert len(rows) == 1
+    assert rows[0]["reference_unpaired"]["depth"] == 1
+    assert rows[0]["candidate_unpaired"]["depth"] == 2
+
+
+def test_compare_directories_rejects_unpaired_artifact_sets(tmp_path):
+    reference = tmp_path / "reference"
+    candidate = tmp_path / "candidate"
+    reference.mkdir()
+    candidate.mkdir()
+    _feature(reference / "missing_af3_input.json")
+
+    with pytest.raises(ValueError, match="missing from candidate"):
+        compare_directories(reference, candidate)

--- a/workflows/mmseqs2-gpu.md
+++ b/workflows/mmseqs2-gpu.md
@@ -1,48 +1,115 @@
-# Batched local MMseqs2-GPU feature generation
+# Experimental local MMseqs2-GPU feature generation
 
-## Goal
+## Status and scope
 
-Generate standard per-protein AlphaFold 3 JSON feature artifacts while amortising local MMseqs2-GPU searches across unique protein sequences.
+This backend is experimental. It replaces AF3's protein MSA searches, so it may
+change MSA depth, template hits, and prediction accuracy. The command-contract
+tests prove that AlphaPulldown can consume real MMseqs2 output; they do **not**
+establish scientific equivalence to jackhmmer. A representative full-database
+MSA-depth/template-hit and downstream DockQ comparison remains a merge gate.
 
-## Confirmed public seam
+The interface is AF3-protein-only. AlphaPulldown's AF2 and AF3 images both carry
+the same pinned binary so cluster images remain symmetric and an AF2 adapter can
+be added without rebuilding the runtime; AF2 feature generation does not consume
+it yet.
 
-`FeatureBatch.generate(requests)` is the behavioral test seam.
+## Two-stage interface
 
-- A `FeatureRequest` contains a unique output name and one protein sequence.
-- The batch is configured with a GPU-capable MMseqs2 process adapter plus explicit UniRef90, MGnify, small-BFD, and paired UniProt GPU-compatible database paths and caller-supplied database identifiers. AlphaPulldown's AF2 and AF3 images bundle the same verified MMseqs2-GPU release, while this feature interface remains AF3-protein-only.
-- The batch also receives the MMseqs2 settings, sequence-count and total-residue chunk limits, output directory, temporary directory, compression choice, native AlphaFold 3 data pipeline, and an MMseqs process adapter.
-- The result identifies written artifacts, reused artifacts, and per-request failures. If any request failed, the caller raises a single nonzero summary after all recoverable work finishes.
-- The observable outputs are standard `<name>_af3_input.json[.xz]` artifacts. MMseqs2 provenance is embedded in each artifact.
+The workflow deliberately releases its GPU before AF3 template search:
 
-The command-line script and workflow are adapters to this seam. Existing AlphaFold 2, remote-MMseqs2, and native AlphaFold 3 paths retain their current behavior.
+1. `create_batch_msas.py` searches the four MMseqs2 databases and atomically
+   writes one durable `<name>_mmseqs_msa.json` bundle per protein. Its
+   `--summary_path` is published only after the entire shard succeeds. If a
+   shard fails, completed bundles remain valid and are reused by its retry.
+2. `finalize_batch_features.py` reads those bundles, runs the native AF3 CPU
+   template and feature pipeline, and writes standard
+   `<name>_af3_input.json[.xz]` artifacts. These jobs can run independently and
+   in parallel without reserving a GPU.
+3. `create_batch_features.py` composes both stages for direct compatibility,
+   but holds one allocation throughout and is not recommended on a scheduler.
 
-## Required behavior
+The GPU entry point does not import AlphaFold or JAX. The core seams are
+`MsaBatch.generate(requests)` and `FeatureFinalizer.generate(requests)`.
 
-1. Validate requests before launching MMseqs2. Only protein sequences are accepted; output names must be unique.
-2. Reuse an existing artifact only when its sequence, MMseqs2 executable version, settings, and every database identifier match. A stale or unreadable artifact is regenerated.
-3. Reuse a valid cached sequence across another missing request with the same sequence.
-4. Deduplicate remaining work by sequence content and preserve first-seen order.
-5. Pack unique sequences without exceeding either configured sequence count or configured total residues. A single sequence larger than the residue limit runs alone.
-6. For each chunk, create one MMseqs2 query database and reuse it for all four searches.
-7. Search UniRef90, MGnify, and small BFD for the unpaired MSA; search UniProt for the paired MSA. One GPU is used. Database discovery is forbidden.
-8. Request aligned FASTA from MMseqs2 and convert query-gap columns to valid A3M insertions. Merge the unpaired alignments without duplicate rows, retain the query as the first row, and preserve complete UniProt descriptions (including taxon metadata) for species-aware pairing.
-9. Pass both MSAs to the native AlphaFold 3 data pipeline with templates unset so its existing template search remains authoritative.
-10. Persist each completed artifact atomically. A killed or failed write must not leave a cacheable partial artifact.
-11. Continue after failures that are isolated to one sequence. Requests sharing a failed sequence fail together; unrelated sequences continue. Batch-wide MMseqs process failures fail only the affected chunk, then later chunks continue.
+## Database prerequisites
 
-## Acceptance criteria
+The paths passed as `mmseqs_*_database_path` must be local MMseqs2 databases
+prepared for GPU search. Build each target from its source FASTA, for example:
 
-- Duplicate sequences are searched once and create separate standard artifacts.
-- Count and residue limits produce deterministic chunks.
-- Matching artifacts avoid MMseqs2; changed settings or database identifiers force regeneration.
-- Unpaired and paired MSAs reach the native AlphaFold 3 pipeline and its resulting templates are preserved.
-- Successful artifacts survive another request's failure, while the result reports the failed request.
-- Compression and uncompressed output names remain compatible with existing AlphaPulldown consumers.
-- Focused tests need no GPU or MMseqs2 installation; only the true external MMseqs process seam uses a fake adapter.
+```bash
+mmseqs createdb uniref90.fasta uniref90
+mmseqs makepaddedseqdb uniref90 uniref90_gpu
+```
 
-## Completion checks
+Repeat this for UniRef90, MGnify, small BFD, and UniProt, then configure the
+`*_gpu` prefixes. Give every build an immutable caller-managed identifier; the
+identifier, MMseqs binary identity, E-value, hit cap, and execution mode are in
+the MSA cache provenance.
 
-- Core behavioral tests pass at the `FeatureBatch.generate` seam.
-- Existing feature-generation regression tests pass.
-- The Snakemake adapter requests one GPU only when local MMseqs2-GPU is enabled and supplies explicit batching/database settings.
-- Snakemake helper and dry-run tests pass.
+All native AF3 databases are still required. MMseqs2 replaces only the four
+protein MSA searches. AF3 still resolves PDB seqres/mmCIF for templates and its
+RNA databases from `--data_dir`. Final artifact provenance therefore also
+includes `--max_template_date`, `--template_seqres_database_id`, and
+`--template_mmcif_database_id`.
+
+GPU database memory can be substantial. Prefer fast node-local storage and an
+Ampere-or-newer GPU. A database larger than VRAM can stream from host RAM, but
+requires enough host memory and runs below peak throughput.
+
+For repeated searches on one persistent node, MMseqs2's advanced `gpuserver`
+mode can avoid repeated database upload. It additionally requires an index made
+with `createindex --index-subset 2`, matching `--max-seqs` and prefilter options
+between server and searches, `--gpu-server 1`, and `--db-load-mode 2`. Ordinary
+Slurm shards cannot assume that a daemon remains on the same node, so the
+workflow currently uses standalone searches.
+
+MMseqs2 GPU search always uses maximum sensitivity; the CPU `-s` option is
+ignored by its GPU prefilter. AlphaPulldown therefore exposes no sensitivity
+knob and does not include one in cache provenance.
+
+## MSA and template behavior
+
+For each chunk, one query database is reused for UniRef90, MGnify, small BFD,
+and paired UniProt searches. Aligned FASTA is converted to A3M while retaining
+insertions and complete UniProt descriptions, including taxonomy metadata.
+Unpaired hits from all three databases are merged and deduplicated.
+
+The finalizer passes that merged unpaired MSA to native AF3 with `templates`
+unset. This matches AF3's own pipeline: it merges UniRef90, small-BFD, and MGnify
+before using the resulting unpaired MSA for template search.
+
+Missing `unpackdb` output is a hard per-shard failure. A query-only alignment is
+never fabricated or cached.
+
+## Validation
+
+Unit tests exercise the public stage seams, including all three unpaired hit
+sources, missing unpack output, provenance invalidation, and partial results.
+The opt-in real command test can be run with:
+
+```bash
+MMSEQS_INTEGRATION_BINARY=/path/to/mmseqs \
+pytest -o addopts="-ra --strict-markers" \
+  test/integration/test_mmseqs2_command_contract.py
+```
+
+It creates a tiny database, pads it, and checks the complete
+`createdb -> search -> result2msa -> unpackdb` filename and content contract in
+CPU contract mode. GPU validation requires a compatible allocated GPU and is
+kept out of ordinary CI; add `MMSEQS_INTEGRATION_GPU=1` to run the same test
+with `search --gpu 1`.
+
+For a representative benchmark, generate matched native and MMseqs2 AF3 feature
+directories and run:
+
+```bash
+compare_msa_backends.py \
+  --reference_dir=/path/to/native_features \
+  --candidate_dir=/path/to/mmseqs_features \
+  --output_path=msa_comparison.json
+```
+
+The report records raw/unique MSA depth, mean non-gap coverage, template counts,
+and exact paired artifact paths. Use those same inputs for matched inference and
+external DockQ evaluation against experimental references; the report explicitly
+does not treat MSA statistics as an accuracy result.

--- a/workflows/mmseqs2-gpu.md
+++ b/workflows/mmseqs2-gpu.md
@@ -25,7 +25,7 @@ The command-line script and workflow are adapters to this seam. Existing AlphaFo
 5. Pack unique sequences without exceeding either configured sequence count or configured total residues. A single sequence larger than the residue limit runs alone.
 6. For each chunk, create one MMseqs2 query database and reuse it for all four searches.
 7. Search UniRef90, MGnify, and small BFD for the unpaired MSA; search UniProt for the paired MSA. One GPU is used. Database discovery is forbidden.
-8. Merge the unpaired alignments without duplicate rows and retain the query as the first row. Preserve UniProt headers in the paired alignment.
+8. Request aligned FASTA from MMseqs2 and convert query-gap columns to valid A3M insertions. Merge the unpaired alignments without duplicate rows, retain the query as the first row, and preserve complete UniProt descriptions (including taxon metadata) for species-aware pairing.
 9. Pass both MSAs to the native AlphaFold 3 data pipeline with templates unset so its existing template search remains authoritative.
 10. Persist each completed artifact atomically. A killed or failed write must not leave a cacheable partial artifact.
 11. Continue after failures that are isolated to one sequence. Requests sharing a failed sequence fail together; unrelated sequences continue. Batch-wide MMseqs process failures fail only the affected chunk, then later chunks continue.

--- a/workflows/mmseqs2-gpu.md
+++ b/workflows/mmseqs2-gpu.md
@@ -9,7 +9,7 @@ Generate standard per-protein AlphaFold 3 JSON feature artifacts while amortisin
 `FeatureBatch.generate(requests)` is the behavioral test seam.
 
 - A `FeatureRequest` contains a unique output name and one protein sequence.
-- The batch is configured with explicit UniRef90, MGnify, small-BFD, and paired UniProt database paths and caller-supplied database identifiers.
+- The batch is configured with a GPU-capable MMseqs2 process adapter plus explicit UniRef90, MGnify, small-BFD, and paired UniProt GPU-compatible database paths and caller-supplied database identifiers. AlphaPulldown's AF2 and AF3 images bundle the same verified MMseqs2-GPU release, while this feature interface remains AF3-protein-only.
 - The batch also receives the MMseqs2 settings, sequence-count and total-residue chunk limits, output directory, temporary directory, compression choice, native AlphaFold 3 data pipeline, and an MMseqs process adapter.
 - The result identifies written artifacts, reused artifacts, and per-request failures. If any request failed, the caller raises a single nonzero summary after all recoverable work finishes.
 - The observable outputs are standard `<name>_af3_input.json[.xz]` artifacts. MMseqs2 provenance is embedded in each artifact.
@@ -19,7 +19,7 @@ The command-line script and workflow are adapters to this seam. Existing AlphaFo
 ## Required behavior
 
 1. Validate requests before launching MMseqs2. Only protein sequences are accepted; output names must be unique.
-2. Reuse an existing artifact only when its sequence, MMseqs2 settings, and every database identifier match. A stale or unreadable artifact is regenerated.
+2. Reuse an existing artifact only when its sequence, MMseqs2 executable version, settings, and every database identifier match. A stale or unreadable artifact is regenerated.
 3. Reuse a valid cached sequence across another missing request with the same sequence.
 4. Deduplicate remaining work by sequence content and preserve first-seen order.
 5. Pack unique sequences without exceeding either configured sequence count or configured total residues. A single sequence larger than the residue limit runs alone.

--- a/workflows/mmseqs2-gpu.md
+++ b/workflows/mmseqs2-gpu.md
@@ -1,0 +1,48 @@
+# Batched local MMseqs2-GPU feature generation
+
+## Goal
+
+Generate standard per-protein AlphaFold 3 JSON feature artifacts while amortising local MMseqs2-GPU searches across unique protein sequences.
+
+## Confirmed public seam
+
+`FeatureBatch.generate(requests)` is the behavioral test seam.
+
+- A `FeatureRequest` contains a unique output name and one protein sequence.
+- The batch is configured with explicit UniRef90, MGnify, small-BFD, and paired UniProt database paths and caller-supplied database identifiers.
+- The batch also receives the MMseqs2 settings, sequence-count and total-residue chunk limits, output directory, temporary directory, compression choice, native AlphaFold 3 data pipeline, and an MMseqs process adapter.
+- The result identifies written artifacts, reused artifacts, and per-request failures. If any request failed, the caller raises a single nonzero summary after all recoverable work finishes.
+- The observable outputs are standard `<name>_af3_input.json[.xz]` artifacts. MMseqs2 provenance is embedded in each artifact.
+
+The command-line script and workflow are adapters to this seam. Existing AlphaFold 2, remote-MMseqs2, and native AlphaFold 3 paths retain their current behavior.
+
+## Required behavior
+
+1. Validate requests before launching MMseqs2. Only protein sequences are accepted; output names must be unique.
+2. Reuse an existing artifact only when its sequence, MMseqs2 settings, and every database identifier match. A stale or unreadable artifact is regenerated.
+3. Reuse a valid cached sequence across another missing request with the same sequence.
+4. Deduplicate remaining work by sequence content and preserve first-seen order.
+5. Pack unique sequences without exceeding either configured sequence count or configured total residues. A single sequence larger than the residue limit runs alone.
+6. For each chunk, create one MMseqs2 query database and reuse it for all four searches.
+7. Search UniRef90, MGnify, and small BFD for the unpaired MSA; search UniProt for the paired MSA. One GPU is used. Database discovery is forbidden.
+8. Merge the unpaired alignments without duplicate rows and retain the query as the first row. Preserve UniProt headers in the paired alignment.
+9. Pass both MSAs to the native AlphaFold 3 data pipeline with templates unset so its existing template search remains authoritative.
+10. Persist each completed artifact atomically. A killed or failed write must not leave a cacheable partial artifact.
+11. Continue after failures that are isolated to one sequence. Requests sharing a failed sequence fail together; unrelated sequences continue. Batch-wide MMseqs process failures fail only the affected chunk, then later chunks continue.
+
+## Acceptance criteria
+
+- Duplicate sequences are searched once and create separate standard artifacts.
+- Count and residue limits produce deterministic chunks.
+- Matching artifacts avoid MMseqs2; changed settings or database identifiers force regeneration.
+- Unpaired and paired MSAs reach the native AlphaFold 3 pipeline and its resulting templates are preserved.
+- Successful artifacts survive another request's failure, while the result reports the failed request.
+- Compression and uncompressed output names remain compatible with existing AlphaPulldown consumers.
+- Focused tests need no GPU or MMseqs2 installation; only the true external MMseqs process seam uses a fake adapter.
+
+## Completion checks
+
+- Core behavioral tests pass at the `FeatureBatch.generate` seam.
+- Existing feature-generation regression tests pass.
+- The Snakemake adapter requests one GPU only when local MMseqs2-GPU is enabled and supplies explicit batching/database settings.
+- Snakemake helper and dry-run tests pass.


### PR DESCRIPTION
## Summary

- split local AF3 feature generation into a JAX-free GPU MSA stage and independent CPU AF3 template/finalization stage
- use stage-specific settings and results (`MsaBatchResult`/`MsaArtifact` versus feature results); the compatibility facade translates between the two deep interfaces
- share one lightweight, idempotent MMseqs CLI/database flag schema across entry points
- publish each MSA atomically and write a schema-v2 completion manifest with name, basename, size, mtime, and SHA-256 for every written or reused bundle
- reject missing, empty, or malformed MMseqs unpack output; invalid persisted bundles are removed so the next workflow DAG repairs them, while downstream AF3/template failures preserve valid MSAs
- remove the ignored GPU sensitivity setting and include MMseqs/search/database identities in MSA cache provenance
- retain native AF3 template processing and include template cutoff plus PDB-seqres/mmCIF identities in final-feature provenance
- bundle pinned MMseqs2-GPU 18-8cc5c in both AF2 and AF3 images, verified by SHA-256 and `mmseqs version`
- add an MSA-backend comparison harness for depth, coverage, template counts, and matched downstream inference/DockQ inputs

## Scientific status

This backend remains experimental. This PR does **not** establish prediction-accuracy equivalence with native AF3; a representative full-database matched inference/DockQ comparison remains a merge gate.

## Validation

- full local suite with CPU JAX backend: 558 passed, 1 skipped, 24 deselected
- focused MMseqs/feature/container tests: 45 passed
- real CPU contract using pinned MMseqs2-GPU 18-8cc5c: 1 passed; exercised `createdb -> makepaddedseqdb -> search -> result2msa -> unpackdb` through the production adapter
- the AF3 Docker compatibility stage now runs that real CPU contract automatically against `/opt/mmseqs/bin/mmseqs`
- real GPU contract on A100 Slurm job 61423155 passed the production command chain and produced the expected nonempty `0.fasta`
- CI is running for `05c582ee`

Companion workflow PR: KosinskiLab/AlphaPulldownSnakemake#54.

Related resident inference core PR: #636.
