### PR TITLE
feat: optional Foldseek + ESMFold structural template search

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,4 +27,14 @@
   (uniref90, mgnify, small_bfd, merged into one MSA) or paired hits (uniprot, whose
   UniProt taxon headers let AlphaFold 3 pair chains by species). Roles are named, not
   inferred from a position in the configured list.
+- **Structural template search**: finding AlphaFold 2 template hits by predicting the
+  query's fold and searching it against a structure database, in place of searching a
+  sequence profile against a sequence database. It replaces the source of the hits
+  only; featurization stays with AlphaFold 2's own hit featurizer.
+- **Predicted structure cache**: durably published predicted structures, keyed by
+  sequence and valid only for the checkpoint that produced them. Separate from the
+  alignment cache so a refreshed structure database costs a search, not a fold.
+- **Structural template hit**: one structure-to-structure alignment expressed in the
+  terms AlphaFold 2's featurizer needs -- a `<pdbid>_<chain>` name, both aligned rows,
+  and per-column residue indices.
 

--- a/README.md
+++ b/README.md
@@ -948,6 +948,7 @@ manually).
 - `--keep_msas` – refresh **templates only** in features that already exist in `--output_dir`, keeping their MSAs. Use it when the template database or `--max_template_date` has moved but the alignments are still valid: it costs a template search (minutes) instead of a full MSA run (hours). Works for both pipelines — AlphaFold2 features get their `template_*` block replaced, AlphaFold3 features are re-processed through AF3's "search for templates only" path. Proteins with no stored features are generated normally, and it takes precedence over `--skip_existing`. Cannot be combined with `--use_mmseqs2` (which fetches MSAs and templates together) or `--skip_msa` (no MSAs to keep).
 - `--seq_index N` – only process the N‑th sequence from the FASTA list.
 - `--use_hhsearch`, `--re_search_templates_mmseqs2` – toggle template search implementations.
+- `--use_foldseek_templates` – find templates by structure instead of by sequence (ESMFold + Foldseek, both local). Off by default; needs its own installs and a structure database, see [docs/structural_templates.md](docs/structural_templates.md).
 - `--path_to_mmt`, `--description_file`, `--multiple_mmts` – enable TrueMultimer CSV-driven feature sets.
 - `--max_template_date YYYY-MM-DD` – required cutoff for template structures; keeps runs reproducible.
 

--- a/alphapulldown/feature_batch.py
+++ b/alphapulldown/feature_batch.py
@@ -7,7 +7,6 @@ import dataclasses
 import hashlib
 import json
 import lzma
-import os
 from pathlib import Path
 import subprocess
 import tempfile
@@ -19,6 +18,7 @@ from alphapulldown.utils.feature_metadata import (
     embed_metadata_in_af3_json,
     extract_metadata_from_af3_json,
 )
+from alphapulldown.utils.file_handling import write_atomic_json as _write_atomic
 
 
 _PROTEIN_RESIDUES = frozenset("ACDEFGHIKLMNPQRSTVWYX")
@@ -966,32 +966,6 @@ class FeatureBatch:
                 *final_result.failures,
             ),
         )
-
-
-def _write_atomic(path: Path, payload: Mapping[str, Any]) -> None:
-    """Durably publish JSON so completed cache entries survive worker failure."""
-    text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
-    )
-    temporary_path = Path(temporary_name)
-    try:
-        with os.fdopen(descriptor, "wb") as raw_handle:
-            if path.suffix == ".xz":
-                with lzma.open(raw_handle, "wt", encoding="utf-8") as handle:
-                    handle.write(text)
-            else:
-                raw_handle.write(text.encode("utf-8"))
-            raw_handle.flush()
-            os.fsync(raw_handle.fileno())
-        os.replace(temporary_path, path)
-        directory_fd = os.open(path.parent, os.O_RDONLY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
-    finally:
-        temporary_path.unlink(missing_ok=True)
 
 
 def _database_index_size(path: Path) -> int:

--- a/alphapulldown/scripts/_foldseek_cli.py
+++ b/alphapulldown/scripts/_foldseek_cli.py
@@ -1,0 +1,281 @@
+"""Shared flag schema for the Foldseek + ESMFold structural template path.
+
+One place defines these flags so the feature entry point and the standalone
+structure-prediction stage cannot drift apart, in the same way
+``_mmseqs2_cli`` holds the local MMseqs2 flags.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+from typing import Any, Callable, Mapping
+
+from absl import flags
+
+from alphapulldown.structural_templates import (
+    ALIGNMENT_TYPE_3DI_AA,
+    EsmfoldSettings,
+    EsmfoldStructurePredictor,
+    FoldseekSearchSettings,
+    FoldseekTemplateSearcher,
+    PredictedStructureCache,
+    StructureDatabaseSpec,
+    SubprocessFoldseekProcess,
+)
+
+
+# Every flag this module defines. Recorded once so the metadata filter and the
+# validator cannot fall behind the definitions.
+STRUCTURAL_TEMPLATE_FLAG_NAMES = (
+    "use_foldseek_templates",
+    "foldseek_binary_path",
+    "foldseek_database_path",
+    "foldseek_database_id",
+    "foldseek_temp_dir",
+    "foldseek_e_value",
+    "foldseek_max_hits",
+    "foldseek_min_alignment_tm_score",
+    "foldseek_alignment_type",
+    "foldseek_threads",
+    "structural_template_cache_dir",
+    "esmfold_model_dir",
+    "esmfold_device",
+    "esmfold_chunk_size",
+    "esmfold_max_sequence_length",
+)
+
+# Without these the search cannot be configured at all.
+REQUIRED_WHEN_ENABLED = (
+    "foldseek_database_path",
+    "foldseek_database_id",
+    "esmfold_model_dir",
+)
+
+
+def _define_once(name: str, define: Callable, default, help_text: str) -> None:
+    if name not in flags.FLAGS:
+        define(name, default, help_text)
+
+
+def define_structural_template_flags(*, include_switch: bool = True) -> None:
+    """Register the structural-template flags without duplicating global names."""
+    if include_switch:
+        _define_once(
+            "use_foldseek_templates",
+            flags.DEFINE_boolean,
+            False,
+            "Find templates by structure instead of by sequence: predict the query "
+            "fold with ESMFold and search it against a local Foldseek database. "
+            "Off by default; the sequence-based search is unchanged when it is off.",
+        )
+    _define_once(
+        "foldseek_binary_path",
+        flags.DEFINE_string,
+        shutil.which("foldseek"),
+        "Path to the local Foldseek executable.",
+    )
+    _define_once(
+        "foldseek_database_path",
+        flags.DEFINE_string,
+        None,
+        "Prefix of the local Foldseek structure database to search. Its chains "
+        "must exist in --template_mmcif_dir, so building it from that directory "
+        "is the safe choice.",
+    )
+    _define_once(
+        "foldseek_database_id",
+        flags.DEFINE_string,
+        None,
+        "Immutable identifier for the Foldseek database build. Cached alignments "
+        "are reused only when it matches.",
+    )
+    _define_once(
+        "foldseek_temp_dir",
+        flags.DEFINE_string,
+        None,
+        "Fast local scratch directory for Foldseek. Defaults to a 'tmp' "
+        "subdirectory of --structural_template_cache_dir.",
+    )
+    _define_once(
+        "foldseek_e_value",
+        flags.DEFINE_float,
+        1e-3,
+        "Foldseek search E-value cutoff.",
+    )
+    _define_once(
+        "foldseek_max_hits",
+        flags.DEFINE_integer,
+        100,
+        "Maximum structures Foldseek may return per query. The featuriser keeps "
+        "far fewer, but it discards hits that fail its prefilters.",
+    )
+    _define_once(
+        "foldseek_min_alignment_tm_score",
+        flags.DEFINE_float,
+        0.0,
+        "Discard hits whose alignment TM-score is below this value (0 keeps all).",
+    )
+    _define_once(
+        "foldseek_alignment_type",
+        flags.DEFINE_integer,
+        ALIGNMENT_TYPE_3DI_AA,
+        "Foldseek alignment mode: 1 for TMalign, 2 for 3Di+AA.",
+    )
+    _define_once(
+        "foldseek_threads",
+        flags.DEFINE_integer,
+        8,
+        "CPU threads for Foldseek.",
+    )
+    _define_once(
+        "structural_template_cache_dir",
+        flags.DEFINE_string,
+        None,
+        "Where predicted structures and Foldseek alignments are cached. Defaults "
+        "to a 'structural_templates' subdirectory of --output_dir.",
+    )
+    _define_once(
+        "esmfold_model_dir",
+        flags.DEFINE_string,
+        None,
+        "Local directory holding the ESMFold checkpoint (for example a download "
+        "of facebook/esmfold_v1). Nothing is fetched over the network.",
+    )
+    _define_once(
+        "esmfold_device",
+        flags.DEFINE_string,
+        "cuda",
+        "Torch device for ESMFold, e.g. 'cuda' or 'cpu'.",
+    )
+    _define_once(
+        "esmfold_chunk_size",
+        flags.DEFINE_integer,
+        None,
+        "Chunk the ESMFold trunk to trade speed for GPU memory on long chains.",
+    )
+    _define_once(
+        "esmfold_max_sequence_length",
+        flags.DEFINE_integer,
+        1500,
+        "Refuse to fold sequences longer than this rather than risk an "
+        "out-of-memory kill.",
+    )
+
+
+def structural_templates_enabled(flag_values: flags.FlagValues) -> bool:
+    return bool(getattr(flag_values, "use_foldseek_templates", False))
+
+
+def validate_structural_template_flags(flag_values: flags.FlagValues) -> None:
+    """Fail early, and in one message, when the feature is misconfigured."""
+    if not structural_templates_enabled(flag_values):
+        return
+    missing = [
+        name for name in REQUIRED_WHEN_ENABLED if not getattr(flag_values, name, None)
+    ]
+    if missing:
+        raise ValueError(
+            "--use_foldseek_templates needs "
+            + ", ".join(f"--{name}" for name in missing)
+            + ". Structural template search cannot guess a database or a "
+            "checkpoint location."
+        )
+    if getattr(flag_values, "use_mmseqs2", False):
+        # The remote MMseqs2 path receives MSAs and templates together and has no
+        # separable template search to replace.
+        raise ValueError(
+            "--use_foldseek_templates cannot be combined with --use_mmseqs2: that "
+            "path obtains templates from the remote server, not from a local "
+            "template search."
+        )
+    if getattr(flag_values, "data_pipeline", "alphafold2") != "alphafold2":
+        raise ValueError(
+            "--use_foldseek_templates applies to the AlphaFold 2 data pipeline. "
+            "AlphaFold 3 runs its own template search internally."
+        )
+
+
+def structural_template_metadata_flags(
+    flag_dict: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Drop the structural-template flags from metadata unless they were used.
+
+    Feature metadata is a record of what actually ran. Reporting a Foldseek
+    binary that happened to be on PATH would be wrong, and it would also change
+    the bytes of every feature file produced by a default run.
+    """
+    filtered = dict(flag_dict)
+    if filtered.get("use_foldseek_templates"):
+        return filtered
+    for name in STRUCTURAL_TEMPLATE_FLAG_NAMES:
+        filtered.pop(name, None)
+    return filtered
+
+
+def structure_database_spec(flag_values: flags.FlagValues) -> StructureDatabaseSpec:
+    return StructureDatabaseSpec(
+        name="foldseek",
+        path=Path(flag_values.foldseek_database_path),
+        identifier=flag_values.foldseek_database_id,
+    )
+
+
+def cache_dir(flag_values: flags.FlagValues, *, output_dir: str | Path | None) -> Path:
+    configured = getattr(flag_values, "structural_template_cache_dir", None)
+    if configured:
+        return Path(configured)
+    if not output_dir:
+        raise ValueError(
+            "--structural_template_cache_dir is required when there is no "
+            "--output_dir to derive it from."
+        )
+    return Path(output_dir) / "structural_templates"
+
+
+def foldseek_search_settings(
+    flag_values: flags.FlagValues, *, output_dir: str | Path | None = None
+) -> FoldseekSearchSettings:
+    resolved_cache_dir = cache_dir(flag_values, output_dir=output_dir)
+    temp_dir = flag_values.foldseek_temp_dir or resolved_cache_dir / "tmp"
+    return FoldseekSearchSettings(
+        database=structure_database_spec(flag_values),
+        temp_dir=Path(temp_dir),
+        cache_dir=resolved_cache_dir,
+        e_value=flag_values.foldseek_e_value,
+        max_hits=flag_values.foldseek_max_hits,
+        min_alignment_tm_score=flag_values.foldseek_min_alignment_tm_score,
+        alignment_type=flag_values.foldseek_alignment_type,
+        threads=flag_values.foldseek_threads,
+    )
+
+
+def esmfold_settings(flag_values: flags.FlagValues) -> EsmfoldSettings:
+    return EsmfoldSettings(
+        model_dir=Path(flag_values.esmfold_model_dir),
+        device=flag_values.esmfold_device,
+        chunk_size=flag_values.esmfold_chunk_size,
+        max_sequence_length=flag_values.esmfold_max_sequence_length,
+    )
+
+
+def build_structure_cache(
+    flag_values: flags.FlagValues, *, output_dir: str | Path | None = None
+) -> PredictedStructureCache:
+    """The ESMFold stage on its own, for running structure prediction ahead."""
+    return PredictedStructureCache(
+        cache_dir=cache_dir(flag_values, output_dir=output_dir),
+        predictor=EsmfoldStructurePredictor(esmfold_settings(flag_values)),
+    )
+
+
+def build_foldseek_template_searcher(
+    flag_values: flags.FlagValues, *, output_dir: str | Path | None = None
+) -> FoldseekTemplateSearcher:
+    """The configured searcher, ready to stand in for hmmsearch or HHsearch."""
+    validate_structural_template_flags(flag_values)
+    return FoldseekTemplateSearcher(
+        settings=foldseek_search_settings(flag_values, output_dir=output_dir),
+        structures=build_structure_cache(flag_values, output_dir=output_dir),
+        foldseek_process=SubprocessFoldseekProcess(flag_values.foldseek_binary_path),
+    )

--- a/alphapulldown/scripts/create_individual_features.py
+++ b/alphapulldown/scripts/create_individual_features.py
@@ -46,6 +46,12 @@ from alphapulldown.utils.template_reuse import (
     search_templates,
 )
 from alphapulldown.utils.sequence_types import get_af3_chain_kind
+from alphapulldown.scripts._foldseek_cli import (
+    build_foldseek_template_searcher,
+    define_structural_template_flags,
+    structural_template_metadata_flags,
+    validate_structural_template_flags,
+)
 
 # Try to import AlphaFold3, but it's optional
 AF3_IMPORT_ERROR = None
@@ -181,6 +187,9 @@ flags.DEFINE_float("hb_allowance", 0.4, "")
 flags.DEFINE_float("plddt_threshold", 0, "")
 flags.DEFINE_boolean("multiple_mmts", False, "")
 
+# Optional structural template search (ESMFold + Foldseek), off by default.
+define_structural_template_flags()
+
 FLAGS = flags.FLAGS
 
 AF3_PROTEIN_MSA_DATABASE_FLAGS = frozenset({
@@ -232,6 +241,7 @@ def validate_data_pipeline_flags():
             "--keep_msas cannot be combined with --skip_msa: there are no MSAs "
             "to keep when MSA generation is skipped."
         )
+    validate_structural_template_flags(FLAGS)
 
 def get_database_path(key):
     """Return the absolute path for a given database key, depending on pipeline."""
@@ -380,7 +390,12 @@ def get_af3_feature_metadata(chain_kinds, *, skip_msa, flag_values=None):
     if flag_values is None:
         flag_values = FLAGS.flag_values_dict()
     metadata_flags = filter_af3_metadata_flags(
-        flag_values, chain_kinds, skip_msa=skip_msa
+        # Both halves matter: flag_values carries the paths this run actually
+        # resolved (no mutated global), and the structural-template filter keeps the
+        # Foldseek flags out of provenance unless the feature was used.
+        structural_template_metadata_flags(flag_values),
+        chain_kinds,
+        skip_msa=skip_msa,
     )
     metadata = save_meta_data.get_meta_dict(metadata_flags)
     try:
@@ -397,6 +412,20 @@ def get_af3_feature_metadata(chain_kinds, *, skip_msa, flag_values=None):
 
 def _create_af2_template_stack():
     """Create the AF2 template searcher and featurizer."""
+    if FLAGS.use_foldseek_templates:
+        # A different way of finding hits, not a different way of featurising
+        # them: the hits go to AlphaFold 2's own hit featuriser, which still
+        # reads each template out of --template_mmcif_dir and still applies the
+        # release-date and coverage prefilters.
+        template_searcher = build_foldseek_template_searcher(
+            FLAGS, output_dir=FLAGS.output_dir
+        )
+        template_featuriser = templates.HhsearchHitFeaturizer(
+            mmcif_dir=FLAGS.template_mmcif_dir, max_template_date=FLAGS.max_template_date,
+            max_hits=20, kalign_binary_path=FLAGS.kalign_binary_path,
+            release_dates_path=None, obsolete_pdbs_path=FLAGS.obsolete_pdbs_path
+        )
+        return template_searcher, template_featuriser
     if FLAGS.use_hhsearch:
         template_searcher = hhsearch.HHSearch(
             binary_path=FLAGS.hhsearch_binary_path, databases=[FLAGS.pdb70_database_path]
@@ -500,7 +529,9 @@ def _should_skip_monomer_output(description):
 
 
 def _persist_monomer_outputs(monomer):
-    meta_dict = save_meta_data.get_meta_dict(FLAGS.flag_values_dict())
+    meta_dict = save_meta_data.get_meta_dict(
+        structural_template_metadata_flags(FLAGS.flag_values_dict())
+    )
     metadata_output_path = _metadata_output_path(monomer.description)
     if FLAGS.compress_features:
         with lzma.open(str(metadata_output_path) + ".xz", "wt") as meta_data_outfile:

--- a/alphapulldown/scripts/predict_query_structures.py
+++ b/alphapulldown/scripts/predict_query_structures.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""GPU stage of the structural template path: fold query sequences and cache them.
+
+Structure prediction is the only part of Foldseek template search that wants a
+GPU, and it depends on nothing but the sequence and the ESMFold weights. Running
+it as its own step lets a scheduler put it on a GPU node and leave the Foldseek
+search and the rest of feature generation on CPUs.
+
+Running it is optional. ``create_individual_features.py --use_foldseek_templates``
+folds whatever it does not find in the cache, so this stage only ever moves work
+earlier -- it never becomes a prerequisite.
+"""
+
+from __future__ import annotations
+
+from absl import app, flags, logging
+
+from alphapulldown.scripts._foldseek_cli import (
+    build_structure_cache,
+    define_structural_template_flags,
+)
+from alphapulldown.utils.file_handling import iter_seqs
+
+
+define_structural_template_flags(include_switch=False)
+flags.DEFINE_list("fasta_paths", None, "Paths to protein FASTA files.")
+
+FLAGS = flags.FLAGS
+
+
+def main(argv) -> None:
+    del argv
+    cache = build_structure_cache(FLAGS)
+    written: list[str] = []
+    reused: list[str] = []
+    failures: list[tuple[str, str]] = []
+    for sequence, description in iter_seqs(FLAGS.fasta_paths):
+        already_cached = cache.cached(sequence)
+        try:
+            cache.structure(sequence)
+        except Exception as exc:
+            # One unfoldable sequence should not cost the rest of the shard its
+            # structures; the run still exits nonzero below.
+            failures.append((description, str(exc)))
+            continue
+        (reused if already_cached else written).append(description)
+    logging.info(
+        "Structure prediction stage: %d folded, %d already cached, %d failed",
+        len(written),
+        len(reused),
+        len(failures),
+    )
+    if failures:
+        detail = ", ".join(f"{name} ({error})" for name, error in failures)
+        raise RuntimeError(
+            f"Structure prediction failed for {len(failures)} sequence(s): {detail}"
+        )
+
+
+if __name__ == "__main__":
+    flags.mark_flags_as_required(
+        ["fasta_paths", "structural_template_cache_dir", "esmfold_model_dir"]
+    )
+    app.run(main)

--- a/alphapulldown/structural_templates.py
+++ b/alphapulldown/structural_templates.py
@@ -1,0 +1,819 @@
+"""Structural template search: ESMFold folds the query, Foldseek finds neighbours.
+
+The default AlphaFold 2 path finds templates by *sequence*: an HMM profile built
+from the uniref90 alignment is searched against ``pdb_seqres`` (or a PDB70 HHM
+database) and the resulting alignments become template features. That misses
+templates whose sequence has drifted beyond profile detection but whose fold has
+not, which is precisely the case where a template would help most.
+
+This module offers a second source of the same kind of hit. A structure is
+predicted for the query with ESMFold, Foldseek searches it against a local
+structure database, and each alignment it returns is converted into the
+``parsers.TemplateHit`` that AlphaFold 2 already knows how to featurise.
+
+It is deliberately only a *source of hits*. Featurisation stays with AlphaFold
+2's ``HhsearchHitFeaturizer``, so a Foldseek hit is still resolved to a chain in
+the local mmCIF directory and still passes the same release-date, coverage and
+duplicate prefilters as a sequence hit. The consequence worth stating plainly:
+the Foldseek database must describe chains that exist in ``--template_mmcif_dir``
+as ``<pdbid>.cif``, because that is the file the featuriser opens. Building the
+Foldseek database from that same directory is the way to guarantee it.
+
+Both tools run locally. Nothing here contacts a web service.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+from typing import Any, Mapping, Protocol, Sequence
+
+from absl import logging
+
+from alphapulldown.utils.file_handling import write_atomic_json
+
+
+# Columns requested from Foldseek, in the order Foldseek writes them. The parser
+# is driven by this tuple and every cache entry records it, so reordering or
+# extending the set invalidates cached alignments rather than silently reading
+# one column as another.
+FOLDSEEK_OUTPUT_COLUMNS = (
+    "query",
+    "target",
+    "fident",
+    "alnlen",
+    "qstart",
+    "qend",
+    "tstart",
+    "tend",
+    "evalue",
+    "bits",
+    "qaln",
+    "taln",
+    "alntmscore",
+)
+
+# Foldseek's 3Di+AA Gotoh-Smith-Waterman alignment. TMalign (1) is the other
+# option and is considerably more expensive per hit.
+ALIGNMENT_TYPE_3DI_AA = 2
+ALIGNMENT_TYPE_TMALIGN = 1
+
+_PROTEIN_RESIDUES = frozenset("ACDEFGHIKLMNPQRSTVWYX")
+
+# Suffixes a Foldseek target name carries when its database was built straight
+# from a directory of structure files.
+_STRUCTURE_FILE_SUFFIXES = (".gz", ".zst", ".cif", ".mmcif", ".bcif", ".pdb", ".ent")
+
+_ASSEMBLY_SUFFIX = re.compile(r"-assembly\d+$", re.IGNORECASE)
+_CHAIN_ID = re.compile(r"[A-Za-z0-9.]+")
+
+
+class StructuralTemplateToolMissing(RuntimeError):
+    """A tool this path needs is not installed, or its weights are not present.
+
+    Raised instead of letting ``FileNotFoundError`` or a Hugging Face download
+    attempt escape, because the fix is always an installation step and the user
+    should be told which one.
+    """
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class StructureDatabaseSpec:
+    """A local Foldseek database and its immutable cache identity."""
+
+    name: str
+    path: Path
+    identifier: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class EsmfoldSettings:
+    """Where the ESMFold weights are and how to run them."""
+
+    model_dir: Path
+    device: str = "cuda"
+    # ESMFold's memory use grows with the square of the sequence length. The
+    # trunk can be told to process the pair representation in chunks, trading
+    # time for memory; None leaves the model's own default in place.
+    chunk_size: int | None = None
+    # A refusal with a clear message beats an out-of-memory kill on a GPU node.
+    max_sequence_length: int = 1500
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FoldseekSearchSettings:
+    """Everything the Foldseek stage needs, including its cache location."""
+
+    database: StructureDatabaseSpec
+    temp_dir: Path
+    cache_dir: Path
+    e_value: float = 1e-3
+    # Hits Foldseek may return. The featuriser keeps far fewer, but it discards
+    # hits that fail its prefilters, so the search has to over-supply.
+    max_hits: int = 100
+    min_alignment_tm_score: float = 0.0
+    alignment_type: int = ALIGNMENT_TYPE_3DI_AA
+    threads: int = 8
+
+
+class StructurePredictor(Protocol):
+    """Predicting one structure for one sequence."""
+
+    def identity(self) -> str:
+        """Stable identity of the predictor; cached structures depend on it."""
+
+    def predict(self, sequence: str) -> str:
+        """Return the predicted structure as PDB-format text."""
+
+
+class FoldseekProcess(Protocol):
+    """The operations performed by the external Foldseek executable."""
+
+    def identity(self) -> str: ...
+
+    def search(
+        self, query_structure: Path, settings: FoldseekSearchSettings
+    ) -> str: ...
+
+
+class SubprocessFoldseekProcess:
+    """Production adapter for one local Foldseek executable."""
+
+    def __init__(self, binary_path: str | Path | None):
+        self._binary_path = str(binary_path) if binary_path else ""
+
+    def _run(self, command: Sequence[str]) -> str:
+        if not self._binary_path:
+            raise StructuralTemplateToolMissing(
+                "No Foldseek executable is configured. Install Foldseek "
+                "(https://github.com/steineggerlab/foldseek) and pass "
+                "--foldseek_binary_path, or put 'foldseek' on PATH."
+            )
+        try:
+            completed = subprocess.run(
+                [self._binary_path, *command],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            raise StructuralTemplateToolMissing(
+                f"Foldseek executable not found at {self._binary_path!r}. Install "
+                "Foldseek (https://github.com/steineggerlab/foldseek) and pass "
+                "--foldseek_binary_path."
+            ) from exc
+        except OSError as exc:
+            raise StructuralTemplateToolMissing(
+                f"Foldseek executable at {self._binary_path!r} cannot be run: {exc}"
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            raise RuntimeError(
+                f"Foldseek command failed: {' '.join(command)}\n{stderr}"
+            ) from exc
+        return completed.stdout.strip()
+
+    def identity(self) -> str:
+        """The executable's own version string, recorded in every cache entry."""
+        version = " ".join(self._run(("version",)).split())
+        if not version:
+            raise RuntimeError("Foldseek version command returned no identity")
+        return f"foldseek {version}"
+
+    def search(self, query_structure: Path, settings: FoldseekSearchSettings) -> str:
+        settings.temp_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="alphapulldown_foldseek_", dir=settings.temp_dir
+        ) as temporary_directory:
+            root = Path(temporary_directory)
+            alignments = root / "alignments.m8"
+            work_dir = root / "work"
+            work_dir.mkdir()
+            self._run(
+                (
+                    "easy-search",
+                    str(query_structure),
+                    str(settings.database.path),
+                    str(alignments),
+                    str(work_dir),
+                    "--format-output",
+                    ",".join(FOLDSEEK_OUTPUT_COLUMNS),
+                    "-e",
+                    str(settings.e_value),
+                    "--max-seqs",
+                    str(settings.max_hits),
+                    "--alignment-type",
+                    str(settings.alignment_type),
+                    "--threads",
+                    str(settings.threads),
+                )
+            )
+            try:
+                return alignments.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Foldseek produced no alignment file at {alignments}: {exc}"
+                ) from exc
+
+
+class EsmfoldStructurePredictor:
+    """ESMFold loaded from a local weights directory, held for the process life.
+
+    The weights are several gigabytes and loading them dominates a single
+    prediction, so the loaded model is kept on the instance and reused for every
+    sequence in a run.
+    """
+
+    def __init__(self, settings: EsmfoldSettings):
+        self._settings = settings
+        self._torch = None
+        self._model = None
+        self._tokenizer = None
+
+    def identity(self) -> str:
+        """Identify the weights without paying to load them.
+
+        The directory name alone would not notice a re-downloaded or partially
+        copied checkpoint, so a cheap content-derived witness goes in alongside
+        it, the same way the MMseqs2 path witnesses a database by its index size.
+        """
+        model_dir = Path(self._settings.model_dir)
+        weights = sorted(
+            path
+            for pattern in ("*.safetensors", "*.bin", "*.pt")
+            for path in model_dir.glob(pattern)
+        )
+        fingerprint = ":".join(
+            f"{path.name}={path.stat().st_size}" for path in weights if path.is_file()
+        )
+        if not fingerprint:
+            raise StructuralTemplateToolMissing(
+                f"No ESMFold weight files found in {model_dir}. Download the "
+                "ESMFold checkpoint (for example facebook/esmfold_v1) into that "
+                "directory and pass it with --esmfold_model_dir."
+            )
+        return f"esmfold:{model_dir.name}:{_short_digest(fingerprint)}"
+
+    def predict(self, sequence: str) -> str:
+        sequence = sequence.strip().upper()
+        _validate_protein_sequence(sequence)
+        if len(sequence) > self._settings.max_sequence_length:
+            raise ValueError(
+                f"Sequence of {len(sequence)} residues exceeds the configured "
+                f"ESMFold limit of {self._settings.max_sequence_length}. Raise "
+                "--esmfold_max_sequence_length if the GPU can take it."
+            )
+        torch, model, tokenizer = self._loaded()
+        encoded = tokenizer(
+            [sequence], return_tensors="pt", add_special_tokens=False
+        )
+        encoded = {
+            key: value.to(self._settings.device) for key, value in encoded.items()
+        }
+        with torch.no_grad():
+            output = model(**encoded)
+        structures = model.output_to_pdb(output)
+        if not structures:
+            raise RuntimeError("ESMFold returned no structure for the query sequence")
+        return structures[0]
+
+    def _loaded(self):
+        if self._model is not None:
+            return self._torch, self._model, self._tokenizer
+        try:
+            import torch
+            from transformers import AutoTokenizer, EsmForProteinFolding
+        except ImportError as exc:
+            raise StructuralTemplateToolMissing(
+                "ESMFold needs PyTorch and transformers, which AlphaPulldown does "
+                "not install by default. Install them into the environment "
+                "(pip install 'torch' 'transformers') before using "
+                "--use_foldseek_templates."
+            ) from exc
+
+        model_dir = str(self._settings.model_dir)
+        try:
+            # local_files_only keeps a missing checkpoint a local error instead
+            # of a silent multi-gigabyte download on a compute node.
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_dir, local_files_only=True
+            )
+            model = EsmForProteinFolding.from_pretrained(
+                model_dir, local_files_only=True
+            )
+        except (OSError, ValueError) as exc:
+            raise StructuralTemplateToolMissing(
+                f"Cannot load ESMFold weights from {model_dir}: {exc}. Download "
+                "the checkpoint (for example facebook/esmfold_v1) into that "
+                "directory first."
+            ) from exc
+
+        model = model.to(self._settings.device)
+        model.eval()
+        if self._settings.chunk_size is not None:
+            model.trunk.set_chunk_size(self._settings.chunk_size)
+        self._torch = torch
+        self._model = model
+        self._tokenizer = tokenizer
+        return torch, model, tokenizer
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class StructuralTemplateHit:
+    """One Foldseek alignment, in the terms AlphaFold 2's featuriser needs.
+
+    Kept separate from ``parsers.TemplateHit`` so that parsing, filtering and
+    naming can be tested without importing AlphaFold.
+    """
+
+    index: int
+    name: str
+    query_alignment: str
+    hit_alignment: str
+    query_start: int
+    hit_start: int
+    score: float
+    e_value: float
+    alignment_tm_score: float | None
+
+    @property
+    def aligned_cols(self) -> int:
+        """Columns where query and template both have a residue."""
+        return sum(
+            1
+            for query_residue, hit_residue in zip(
+                self.query_alignment, self.hit_alignment
+            )
+            if query_residue != "-" and hit_residue != "-"
+        )
+
+    def to_template_hit(self):
+        """Convert to the AlphaFold 2 hit the template featuriser consumes."""
+        from alphafold.data import parsers
+
+        indices_query, indices_hit = alignment_indices(
+            self.query_alignment,
+            self.hit_alignment,
+            query_start=self.query_start,
+            hit_start=self.hit_start,
+        )
+        return parsers.TemplateHit(
+            index=self.index,
+            name=self.name,
+            aligned_cols=self.aligned_cols,
+            # Only ever used to rank hits and to fill template_sum_probs. The
+            # Foldseek bit score orders hits the same way its own output does.
+            sum_probs=self.score,
+            query=self.query_alignment,
+            hit_sequence=self.hit_alignment,
+            indices_query=indices_query,
+            indices_hit=indices_hit,
+        )
+
+
+def alignment_indices(
+    query_alignment: str,
+    hit_alignment: str,
+    *,
+    query_start: int,
+    hit_start: int,
+) -> tuple[list[int], list[int]]:
+    """Per-column residue indices, with -1 for a gap, as AlphaFold 2 expects.
+
+    Foldseek reports 1-based inclusive alignment starts; AlphaFold 2 works in
+    0-based indices, so the starts are shifted by one here and nowhere else.
+    """
+    if len(query_alignment) != len(hit_alignment):
+        raise ValueError(
+            "Query and template alignment rows differ in length "
+            f"({len(query_alignment)} vs {len(hit_alignment)})"
+        )
+    if query_start < 1 or hit_start < 1:
+        raise ValueError("Alignment starts are 1-based and must be positive")
+
+    indices_query: list[int] = []
+    indices_hit: list[int] = []
+    query_index = query_start - 1
+    hit_index = hit_start - 1
+    for query_residue, hit_residue in zip(query_alignment, hit_alignment):
+        if query_residue == "-":
+            indices_query.append(-1)
+        else:
+            indices_query.append(query_index)
+            query_index += 1
+        if hit_residue == "-":
+            indices_hit.append(-1)
+        else:
+            indices_hit.append(hit_index)
+            hit_index += 1
+    return indices_query, indices_hit
+
+
+def pdb_chain_name(target: str) -> str | None:
+    """Normalise a Foldseek target name to ``<pdbid>_<chain>``, or None.
+
+    AlphaFold 2 resolves a hit by reading ``<pdbid>.cif`` out of the mmCIF
+    directory, and it parses that identifier straight off the front of the hit
+    name. Foldseek, meanwhile, names targets after the file the database was
+    built from -- ``1abc.cif.gz_A``, ``pdb1abc.ent.gz_A``,
+    ``1abc-assembly1.cif.gz_A`` -- so the name has to be reduced before the hit
+    can be handed over. Anything that does not reduce to a PDB chain (an AFDB
+    model, say) has no mmCIF file to read and returns None so the caller can
+    skip it with a word rather than fail deep inside the featuriser.
+    """
+    token = target.split()[0] if target.split() else ""
+    token = token.rsplit("/", 1)[-1]
+    stem, separator, chain = token.rpartition("_")
+    if not separator or not chain or not _CHAIN_ID.fullmatch(chain):
+        return None
+
+    trimmed = True
+    while trimmed:
+        trimmed = False
+        for suffix in _STRUCTURE_FILE_SUFFIXES:
+            if stem.lower().endswith(suffix):
+                stem = stem[: -len(suffix)]
+                trimmed = True
+    stem = _ASSEMBLY_SUFFIX.sub("", stem)
+    # RCSB's own PDB-format distribution names files pdb<id>.ent.
+    if len(stem) == 7 and stem.lower().startswith("pdb"):
+        stem = stem[3:]
+    if len(stem) != 4 or not stem.isalnum():
+        return None
+    return f"{stem.lower()}_{chain}"
+
+
+def query_sequence_from_a3m(a3m: str) -> str:
+    """The query sequence of an A3M alignment: its first record, ungapped."""
+    started = False
+    parts: list[str] = []
+    for line in a3m.splitlines():
+        if line.startswith(">"):
+            if started:
+                break
+            started = True
+        elif started and line.strip():
+            parts.append(line.strip())
+    if not started or not parts:
+        raise ValueError("A3M alignment contains no query sequence")
+    query = "".join(parts).replace("-", "").replace(".", "").upper()
+    _validate_protein_sequence(query)
+    return query
+
+
+def parse_foldseek_alignments(
+    output: str,
+    query_sequence: str,
+    *,
+    min_alignment_tm_score: float = 0.0,
+    columns: Sequence[str] = FOLDSEEK_OUTPUT_COLUMNS,
+) -> tuple[StructuralTemplateHit, ...]:
+    """Turn Foldseek tabular output into hits AlphaFold 2 can featurise.
+
+    A malformed or unusable row is dropped with a warning rather than failing the
+    whole search: one unreadable target should not cost a query its remaining
+    templates.
+    """
+    field_index = {name: position for position, name in enumerate(columns)}
+    query_sequence = query_sequence.upper()
+    hits: list[StructuralTemplateHit] = []
+    for line in output.splitlines():
+        line = line.rstrip("\n")
+        if not line.strip() or line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        # Foldseek can be asked for a header row; the query column of a real row
+        # holds the query structure file name, which is never literally "query".
+        if fields[0] == "query" and len(fields) > 1 and fields[1] == "target":
+            continue
+        if len(fields) != len(columns):
+            logging.warning(
+                "Ignoring a Foldseek row with %d fields, expected %d: %.120s",
+                len(fields),
+                len(columns),
+                line,
+            )
+            continue
+
+        target = fields[field_index["target"]]
+        name = pdb_chain_name(target)
+        if name is None:
+            logging.warning(
+                "Ignoring Foldseek hit %r: it does not name a PDB chain, so no "
+                "mmCIF file can be read for it.",
+                target,
+            )
+            continue
+
+        try:
+            query_start = int(fields[field_index["qstart"]])
+            hit_start = int(fields[field_index["tstart"]])
+            query_end = int(fields[field_index["qend"]])
+            score = float(fields[field_index["bits"]])
+            e_value = float(fields[field_index["evalue"]])
+        except ValueError:
+            logging.warning(
+                "Ignoring a Foldseek row with unreadable numbers: %.120s", line
+            )
+            continue
+
+        query_alignment = fields[field_index["qaln"]].upper()
+        hit_alignment = fields[field_index["taln"]].upper()
+        if len(query_alignment) != len(hit_alignment) or not query_alignment:
+            logging.warning(
+                "Ignoring Foldseek hit %r: its alignment rows are unusable.", target
+            )
+            continue
+
+        # The featuriser locates the aligned region by searching for it in the
+        # query sequence, so a row that does not correspond to this query would
+        # be mapped to the wrong residues instead of rejected.
+        aligned_query = query_alignment.replace("-", "")
+        if query_sequence[query_start - 1 : query_end] != aligned_query:
+            logging.warning(
+                "Ignoring Foldseek hit %r: its query alignment does not match the "
+                "query sequence at residues %d-%d.",
+                target,
+                query_start,
+                query_end,
+            )
+            continue
+
+        alignment_tm_score = _optional_float(fields[field_index["alntmscore"]])
+        if (
+            min_alignment_tm_score > 0.0
+            and alignment_tm_score is not None
+            and alignment_tm_score < min_alignment_tm_score
+        ):
+            continue
+
+        hits.append(
+            StructuralTemplateHit(
+                index=len(hits),
+                name=name,
+                query_alignment=query_alignment,
+                hit_alignment=hit_alignment,
+                query_start=query_start,
+                hit_start=hit_start,
+                score=score,
+                e_value=e_value,
+                alignment_tm_score=alignment_tm_score,
+            )
+        )
+    return tuple(hits)
+
+
+class PredictedStructureCache:
+    """Predicted query structures, published durably and keyed by sequence.
+
+    Folding is the only step here that wants a GPU, and it depends on nothing but
+    the sequence and the weights. Keeping it behind its own cache means it can be
+    run once, ahead of time, on a GPU node -- and that re-searching a refreshed
+    Foldseek database later costs a Foldseek run rather than a GPU run.
+    """
+
+    def __init__(self, *, cache_dir: Path, predictor: StructurePredictor):
+        self._cache_dir = Path(cache_dir)
+        self._predictor = predictor
+        self._identity: str | None = None
+
+    def signature(self) -> dict[str, Any]:
+        """What a cached structure has to have been produced by to be reused."""
+        return {"schema_version": 1, "predictor": self.predictor_identity()}
+
+    def predictor_identity(self) -> str:
+        if self._identity is None:
+            identity = self._predictor.identity().strip()
+            if not identity:
+                raise ValueError("Structure predictor identity must not be empty")
+            self._identity = identity
+        return self._identity
+
+    def structure(self, sequence: str) -> str:
+        """The predicted structure for one sequence, folding it if necessary."""
+        sequence = sequence.strip().upper()
+        _validate_protein_sequence(sequence)
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        path = self.path(sequence)
+        cached = _read_cached(path, sequence, self.signature())
+        if cached is not None:
+            logging.info("Reusing a cached predicted structure for the query sequence")
+            return cached["structure"]
+        structure = self._predictor.predict(sequence)
+        if not structure.strip():
+            raise RuntimeError("The structure predictor returned an empty structure")
+        write_atomic_json(
+            path,
+            {
+                "schemaVersion": 1,
+                "sequence": sequence,
+                "structure": structure,
+                "provenance": self.signature(),
+            },
+        )
+        return structure
+
+    def cached(self, sequence: str) -> bool:
+        """Whether a reusable structure for this sequence is already published."""
+        sequence = sequence.strip().upper()
+        return _read_cached(self.path(sequence), sequence, self.signature()) is not None
+
+    def path(self, sequence: str) -> Path:
+        """Where the structure for one sequence is cached, folded or not yet."""
+        digest = _short_digest(sequence.strip().upper())
+        return self._cache_dir / f"{digest}_esmfold.json"
+
+
+class FoldseekTemplateSearcher:
+    """AlphaFold 2's template-searcher interface, backed by ESMFold and Foldseek.
+
+    ``input_format``, ``output_format``, ``query`` and ``get_template_hits`` are
+    the four things AlphaFold 2's data pipeline asks of a template searcher, so
+    implementing them is all it takes to substitute this for hmmsearch or
+    HHsearch. The pipeline hands ``query`` the uniref90 alignment; only its first
+    row is used, because a fold is predicted from the query sequence alone.
+    """
+
+    def __init__(
+        self,
+        *,
+        settings: FoldseekSearchSettings,
+        structures: PredictedStructureCache,
+        foldseek_process: FoldseekProcess,
+    ):
+        if not isinstance(settings, FoldseekSearchSettings):
+            raise TypeError(
+                "FoldseekTemplateSearcher settings must be FoldseekSearchSettings"
+            )
+        _validate_search_settings(settings)
+        self._settings = settings
+        self._structures = structures
+        self._foldseek = foldseek_process
+        self._foldseek_identity: str | None = None
+
+    @property
+    def input_format(self) -> str:
+        return "a3m"
+
+    @property
+    def output_format(self) -> str:
+        return "m8"
+
+    def query(self, a3m: str) -> str:
+        """Return Foldseek tabular output for the alignment's query sequence."""
+        sequence = query_sequence_from_a3m(a3m)
+        self._settings.cache_dir.mkdir(parents=True, exist_ok=True)
+        cached = _read_cached(
+            self._alignment_path(sequence), sequence, self._alignment_signature()
+        )
+        if cached is not None:
+            logging.info("Reusing cached Foldseek alignments for the query sequence")
+            return cached["alignments"]
+
+        structure = self._structures.structure(sequence)
+        self._settings.temp_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="alphapulldown_foldseek_query_", dir=self._settings.temp_dir
+        ) as temporary_directory:
+            # Named after the sequence digest so a stray file in a shared scratch
+            # directory can be traced back, and so no target can be mistaken for
+            # a header row.
+            query_structure = (
+                Path(temporary_directory) / f"{_short_digest(sequence)}.pdb"
+            )
+            query_structure.write_text(structure, encoding="utf-8")
+            alignments = self._foldseek.search(query_structure, self._settings)
+
+        write_atomic_json(
+            self._alignment_path(sequence),
+            {
+                "schemaVersion": 1,
+                "sequence": sequence,
+                "alignments": alignments,
+                "provenance": self._alignment_signature(),
+            },
+        )
+        return alignments
+
+    def get_template_hits(self, output_string: str, input_sequence: str):
+        """Parsed AlphaFold 2 template hits for one Foldseek output."""
+        hits = parse_foldseek_alignments(
+            output_string,
+            input_sequence,
+            min_alignment_tm_score=self._settings.min_alignment_tm_score,
+        )
+        if not hits:
+            logging.warning(
+                "Foldseek returned no usable structural template hits for this query."
+            )
+        return [hit.to_template_hit() for hit in hits]
+
+    def provenance(self) -> dict[str, Any]:
+        """Complete identity of this search, for feature metadata."""
+        return self._alignment_signature()
+
+    def _alignment_signature(self) -> dict[str, Any]:
+        database = self._settings.database
+        return {
+            "schema_version": 1,
+            "predictor": self._structures.predictor_identity(),
+            "foldseek": self._foldseek_id(),
+            "database": {
+                "name": database.name,
+                "identifier": database.identifier,
+                # `identifier` is operator-supplied and cannot notice a database
+                # rebuilt or half-copied under the same name; the index size is a
+                # cheap content-derived witness that changes when it does.
+                "index_size": _database_index_size(database.path),
+            },
+            "e_value": self._settings.e_value,
+            "max_hits": self._settings.max_hits,
+            "alignment_type": self._settings.alignment_type,
+            "min_alignment_tm_score": self._settings.min_alignment_tm_score,
+            "columns": list(FOLDSEEK_OUTPUT_COLUMNS),
+        }
+
+    def _foldseek_id(self) -> str:
+        if self._foldseek_identity is None:
+            identity = self._foldseek.identity().strip()
+            if not identity:
+                raise ValueError("Foldseek identity must not be empty")
+            self._foldseek_identity = identity
+        return self._foldseek_identity
+
+    def _alignment_path(self, sequence: str) -> Path:
+        return self._settings.cache_dir / f"{_short_digest(sequence)}_foldseek.json"
+
+
+def _validate_search_settings(settings: FoldseekSearchSettings) -> None:
+    if not str(settings.database.path):
+        raise ValueError("The Foldseek database requires an explicit path")
+    if not settings.database.identifier.strip():
+        raise ValueError("The Foldseek database requires a non-empty identifier")
+    if settings.e_value <= 0:
+        raise ValueError("e_value must be greater than 0")
+    if settings.max_hits < 1:
+        raise ValueError("max_hits must be at least 1")
+    if settings.threads < 1:
+        raise ValueError("threads must be at least 1")
+    if not 0.0 <= settings.min_alignment_tm_score <= 1.0:
+        raise ValueError("min_alignment_tm_score must lie between 0 and 1")
+    if settings.alignment_type not in (ALIGNMENT_TYPE_TMALIGN, ALIGNMENT_TYPE_3DI_AA):
+        raise ValueError(
+            "alignment_type must be "
+            f"{ALIGNMENT_TYPE_TMALIGN} (TMalign) or {ALIGNMENT_TYPE_3DI_AA} (3Di+AA)"
+        )
+
+
+def _read_cached(
+    path: Path, sequence: str, signature: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    """A cache entry for this sequence and these settings, or None."""
+    if not path.exists():
+        return None
+    try:
+        with open(path, "rt", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("sequence") != sequence:
+            return None
+        if payload.get("provenance") != dict(signature):
+            return None
+        return payload
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _validate_protein_sequence(sequence: str) -> None:
+    if not sequence or set(sequence.upper()) - _PROTEIN_RESIDUES:
+        raise ValueError(
+            "Structural template search needs a protein sequence; got "
+            f"{sequence[:40]!r}"
+        )
+
+
+def _optional_float(value: str) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if parsed != parsed else parsed
+
+
+def _short_digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _database_index_size(path: Path) -> int:
+    """Size of a Foldseek database index, or 0 when it cannot be read."""
+    try:
+        return Path(f"{path}.index").stat().st_size
+    except OSError:
+        return 0

--- a/alphapulldown/utils/file_handling.py
+++ b/alphapulldown/utils/file_handling.py
@@ -2,11 +2,47 @@ import os
 from absl import logging
 import csv
 import contextlib
+import json
 import lzma
 import tempfile
 from pathlib import Path
+from typing import Any, Mapping
 
 AF3_INPUT_SUFFIX = "_af3_input.json"
+
+
+def write_atomic_json(path, payload: Mapping[str, Any]) -> None:
+    """Durably publish JSON so a completed cache entry survives worker failure.
+
+    Writes to a temporary file in the destination directory, fsyncs it, renames
+    it into place and fsyncs the directory. A reader therefore sees either the
+    previous content or the complete new content, never a half-written file --
+    which matters because everything written this way is a cache entry that a
+    later run will trust. A ``.xz`` suffix selects lzma compression.
+    """
+    path = Path(path)
+    text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as raw_handle:
+            if path.suffix == ".xz":
+                with lzma.open(raw_handle, "wt", encoding="utf-8") as handle:
+                    handle.write(text)
+            else:
+                raw_handle.write(text.encode("utf-8"))
+            raw_handle.flush()
+            os.fsync(raw_handle.fileno())
+        os.replace(temporary_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
 def read_maybe_xz(path) -> str:
     """Read a text file that may be lzma-compressed, chosen by its suffix."""

--- a/docs/structural_templates.md
+++ b/docs/structural_templates.md
@@ -1,0 +1,176 @@
+# Structural templates with Foldseek and ESMFold
+
+AlphaPulldown normally finds AlphaFold 2 templates by *sequence*: a profile built
+from the uniref90 alignment is searched against `pdb_seqres` with hmmsearch (or
+against PDB70 with HHsearch when `--use_hhsearch` is set), and the resulting
+alignments become the `template_*` block of the features.
+
+`--use_foldseek_templates` replaces that search with a structural one. ESMFold
+predicts a structure for the query sequence, Foldseek searches that structure
+against a local structure database, and each alignment it returns becomes a
+template hit. It is useful when a template's sequence has drifted far enough that
+a profile search no longer finds it but its fold is still recognisable.
+
+The feature is off by default. With it off, nothing about feature generation
+changes — not the search, not the features, not their metadata.
+
+## What changes and what does not
+
+Only the *source of the hits* changes. The hits are handed to AlphaFold 2's own
+`HhsearchHitFeaturizer`, so:
+
+- every template is still read out of `--template_mmcif_dir` as `<pdbid>.cif`;
+- `--max_template_date`, the coverage and duplicate prefilters, and the cap of 20
+  templates per query all still apply;
+- MSA generation is untouched, so the run still needs the sequence databases.
+
+The consequence worth planning around: **the Foldseek database must describe
+chains that exist in `--template_mmcif_dir`.** A hit whose name does not reduce to
+a PDB chain — an AlphaFold DB model, say — is skipped with a warning, because
+there is no mmCIF file to featurise it from.
+
+## What you have to install
+
+None of this is installed with AlphaPulldown.
+
+1. **Foldseek.** A release binary or a conda install; see
+   <https://github.com/steineggerlab/foldseek>. Point `--foldseek_binary_path` at
+   it, or leave it on `PATH`.
+2. **PyTorch and transformers**, for ESMFold: `pip install torch transformers`.
+3. **ESMFold weights** in a local directory — a download of the published
+   `facebook/esmfold_v1` checkpoint, for example. AlphaPulldown loads it with
+   `local_files_only`, so nothing is fetched at run time and a missing checkpoint
+   is a local error rather than a silent multi-gigabyte download on a compute
+   node.
+4. **A Foldseek structure database** (below).
+
+## Building the structure database
+
+Build it from the same mmCIF directory the featuriser reads, and the two cannot
+disagree:
+
+```bash
+foldseek createdb /path/to/pdb_mmcif/mmcif_files /path/to/foldseek/pdb
+foldseek createindex /path/to/foldseek/pdb /path/to/scratch   # optional
+```
+
+Foldseek names its targets after the files it was built from, so entries come out
+as `1abc.cif.gz_A`. AlphaPulldown reduces those to `1abc_A`, which is what
+AlphaFold 2 needs in order to open `1abc.cif`. The common decorations
+(`pdb1abc.ent.gz_A`, `1abc-assembly1.cif.gz_A`) are understood too.
+
+## Running it
+
+```bash
+create_individual_features.py \
+  --fasta_paths=proteins.fasta \
+  --data_dir=$ALPHAFOLD_DATA_DIR \
+  --output_dir=features \
+  --max_template_date=2024-01-01 \
+  --use_foldseek_templates \
+  --foldseek_database_path=/path/to/foldseek/pdb \
+  --foldseek_database_id=pdb-mmcif-2024-01 \
+  --esmfold_model_dir=/path/to/esmfold_v1 \
+  --esmfold_device=cuda
+```
+
+`--keep_msas` works with it: an existing feature set can have only its templates
+replaced, using the structural search instead of the sequence one.
+
+## Running the GPU step separately
+
+Folding the query is the only part that wants a GPU, and it depends on nothing
+but the sequence and the checkpoint. `predict_query_structures.py` does just that
+step and caches the result:
+
+```bash
+predict_query_structures.py \
+  --fasta_paths=proteins.fasta \
+  --structural_template_cache_dir=/scratch/structural_templates \
+  --esmfold_model_dir=/path/to/esmfold_v1 \
+  --esmfold_device=cuda
+```
+
+Feature generation then reuses those structures, so it can run on CPU nodes.
+Point it at the same `--structural_template_cache_dir` and the same
+`--esmfold_model_dir`: the checkpoint directory is still read (its file sizes
+identify the weights that produced a cached structure), but the model itself is
+never loaded when every structure is already cached.
+
+Running this stage is optional. Feature generation folds whatever it does not
+find, so skipping it only moves the work, never breaks the run.
+
+## Flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--use_foldseek_templates` | `False` | Turn structural template search on. |
+| `--foldseek_binary_path` | `which foldseek` | The Foldseek executable. |
+| `--foldseek_database_path` | — | Prefix of the Foldseek database. Required. |
+| `--foldseek_database_id` | — | Immutable name of that database build. Required. |
+| `--foldseek_temp_dir` | `<cache>/tmp` | Foldseek scratch directory. |
+| `--foldseek_e_value` | `1e-3` | Search E-value cutoff. |
+| `--foldseek_max_hits` | `100` | Structures Foldseek may return per query. |
+| `--foldseek_min_alignment_tm_score` | `0.0` | Drop hits below this alignment TM-score. |
+| `--foldseek_alignment_type` | `2` | `1` for TMalign, `2` for 3Di+AA. |
+| `--foldseek_threads` | `8` | CPU threads for Foldseek. |
+| `--structural_template_cache_dir` | `<output_dir>/structural_templates` | Where structures and alignments are cached. |
+| `--esmfold_model_dir` | — | Local ESMFold checkpoint directory. Required. |
+| `--esmfold_device` | `cuda` | Torch device for ESMFold. |
+| `--esmfold_chunk_size` | unset | Chunk the trunk to trade speed for GPU memory. |
+| `--esmfold_max_sequence_length` | `1500` | Refuse longer sequences rather than risk an out-of-memory kill. |
+
+## Caching and provenance
+
+Two caches live under `--structural_template_cache_dir`, keyed by the sequence:
+
+- `<digest>_esmfold.json` — the predicted structure and the identity of the
+  checkpoint that produced it.
+- `<digest>_foldseek.json` — Foldseek's output and the full identity of the
+  search: checkpoint, Foldseek version, database identifier and index size,
+  E-value, hit cap, alignment type, TM-score threshold, and the exact columns
+  requested.
+
+A cache entry is reused only when that record matches exactly, so a rebuilt
+database, a new checkpoint or a changed setting invalidates the alignments. The
+two are separate on purpose: re-searching a refreshed database costs a Foldseek
+run, not a GPU run.
+
+`--foldseek_database_id` is yours to choose and should name the build, not the
+path. Because an operator-supplied name cannot notice a database that was rebuilt
+or half-copied under the same name, the index size is recorded alongside it as a
+content-derived witness.
+
+The raw Foldseek output is also written to `pdb_hits.m8` in the MSA output
+directory, where the sequence-based search writes `pdb_hits.sto` or
+`pdb_hits.hhr`.
+
+Feature metadata records the structural-template flags only when the feature was
+actually used, so a Foldseek binary that merely happens to be on `PATH` never
+appears in the provenance of features it did not produce.
+
+## Limitations
+
+- **AlphaFold 2 features only.** AlphaFold 3 runs its own template search inside
+  its data pipeline; combining the two is rejected with an error.
+- **Not with `--use_mmseqs2`.** The remote MMseqs2 path receives MSAs and
+  templates together and has no separable template search to replace.
+- **Proteins only.**
+- Multimeric templates (`--path_to_mmt`) are a separate mechanism and are
+  unaffected.
+- `template_sum_probs` carries the Foldseek bit score rather than an HHsearch
+  probability. It is used to rank hits and is not consumed by the model.
+
+## When something is missing
+
+Each of these is reported as a plain message naming the fix, not a traceback:
+
+- no Foldseek executable configured, or the configured path does not exist;
+- PyTorch or transformers not installed;
+- no weight files in `--esmfold_model_dir`, or a checkpoint that will not load;
+- a query longer than `--esmfold_max_sequence_length`.
+
+A Foldseek run that fails reports Foldseek's own stderr. Individual hits that
+cannot be used — an unparsable row, a target with no mmCIF file, an alignment
+that does not belong to this query — are dropped with a warning so that one bad
+target does not cost the query its remaining templates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ script-files = [
   "./alphapulldown/scripts/create_batch_msas.py",
   "./alphapulldown/scripts/finalize_batch_features.py",
   "./alphapulldown/scripts/compare_msa_backends.py",
+  "./alphapulldown/scripts/predict_query_structures.py",
   "./alphapulldown/scripts/run_multimer_jobs.py",
   "./alphapulldown/scripts/generate_alphafold_server_json.py",
   "./alphapulldown/analysis_pipeline/create_notebook.py",

--- a/test/cluster/check_structural_templates.py
+++ b/test/cluster/check_structural_templates.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python
+"""GPU smoke test for the whole structural-template chain.
+
+Runs the real thing end to end: ESMFold folds a query on a GPU, Foldseek searches
+that structure against a real local structure database, and AlphaFold 2's own
+featuriser turns the hits into a ``template_*`` feature block. The assertions are
+about that block being *structurally valid* -- right keys, shapes, dtypes,
+non-empty, and a residue mapping that stays inside the query -- because a broken
+offset or a mis-shaped feature is accepted silently by everything downstream and
+only shows up as a bad model.
+
+Nothing here runs in CI. It skips cleanly whenever the GPU, the Foldseek binary,
+the structure database, the ESMFold weights or the mmCIF directory is missing.
+
+Configuration, all environment variables:
+
+- ``FOLDSEEK_BINARY``            Foldseek executable (default: found on PATH)
+- ``FOLDSEEK_DATABASE_PATH``     prefix of a Foldseek database of PDB chains
+- ``FOLDSEEK_DATABASE_ID``       its immutable build name (default: a placeholder)
+- ``ESMFOLD_MODEL_DIR``          local ESMFold checkpoint directory
+- ``ALPHAFOLD_DATA_DIR``         AlphaFold 2 databases; supplies the mmCIF directory
+- ``TEMPLATE_MMCIF_DIR``         overrides the mmCIF directory directly
+- ``RUN_GPU_FUNCTIONAL_TESTS``   set to 1 to run where a GPU is present
+
+Submit it with ``python test/cluster/run_structural_templates.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import lzma
+import os
+import pickle
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pytest
+from absl.testing import absltest, parameterized
+
+pytestmark = [pytest.mark.cluster, pytest.mark.gpu, pytest.mark.external_tools]
+
+import alphapulldown  # noqa: E402
+from alphapulldown.structural_templates import (  # noqa: E402
+    EsmfoldSettings,
+    EsmfoldStructurePredictor,
+    FoldseekSearchSettings,
+    FoldseekTemplateSearcher,
+    PredictedStructureCache,
+    StructureDatabaseSpec,
+    SubprocessFoldseekProcess,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_ROOT = REPO_ROOT / "test"
+
+# Short enough to fold quickly, long enough that a template alignment is
+# meaningful. Ubiquitin; any small well-represented protein would do.
+QUERY_NAME = "ubiquitin"
+QUERY_SEQUENCE = (
+    "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG"
+)
+
+MAX_TEMPLATE_DATE = os.getenv("MAX_TEMPLATE_DATE", "2024-01-01")
+
+TEMPLATE_FEATURE_SPECS = {
+    "template_aatype": (np.floating, 3),
+    "template_all_atom_masks": (np.floating, 3),
+    "template_all_atom_positions": (np.floating, 4),
+    "template_domain_names": (np.object_, 1),
+    "template_sequence": (np.object_, 1),
+    "template_sum_probs": (np.floating, 2),
+}
+
+
+# --------------------------------------------------------------------------- #
+#                              skip conditions                                #
+# --------------------------------------------------------------------------- #
+def _has_nvidia_gpu() -> bool:
+    nvidia_smi = shutil.which("nvidia-smi")
+    if not nvidia_smi:
+        return False
+    try:
+        result = subprocess.run(
+            [nvidia_smi, "-L"], capture_output=True, text=True, check=False
+        )
+    except OSError:
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _foldseek_binary() -> str | None:
+    binary = os.getenv("FOLDSEEK_BINARY") or shutil.which("foldseek")
+    return binary if binary and Path(binary).is_file() else None
+
+
+def _template_mmcif_dir() -> Path | None:
+    configured = os.getenv("TEMPLATE_MMCIF_DIR")
+    if configured:
+        directory = Path(configured)
+    else:
+        data_dir = os.getenv("ALPHAFOLD_DATA_DIR")
+        if not data_dir:
+            return None
+        directory = Path(data_dir) / "pdb_mmcif" / "mmcif_files"
+    return directory if directory.is_dir() else None
+
+
+def _skip_reason() -> str | None:
+    """One place that decides whether this smoke test can run at all."""
+    if os.getenv("RUN_GPU_FUNCTIONAL_TESTS", "").lower() not in ("1", "true", "yes"):
+        if os.getenv("CI", "").lower() in ("1", "true", "yes"):
+            return "GPU smoke tests are disabled on CI."
+        if not _has_nvidia_gpu():
+            return "A GPU is required; set RUN_GPU_FUNCTIONAL_TESTS=1 to override."
+    if _foldseek_binary() is None:
+        return "Foldseek is not installed; set FOLDSEEK_BINARY."
+    if not os.getenv("FOLDSEEK_DATABASE_PATH"):
+        return "Set FOLDSEEK_DATABASE_PATH to a local Foldseek structure database."
+    if not Path(f"{os.environ['FOLDSEEK_DATABASE_PATH']}.index").is_file():
+        return (
+            "FOLDSEEK_DATABASE_PATH does not look like a Foldseek database "
+            f"({os.environ['FOLDSEEK_DATABASE_PATH']}.index is missing)."
+        )
+    model_dir = os.getenv("ESMFOLD_MODEL_DIR")
+    if not model_dir or not Path(model_dir).is_dir():
+        return "Set ESMFOLD_MODEL_DIR to a local ESMFold checkpoint directory."
+    try:
+        import torch  # noqa: F401
+        import transformers  # noqa: F401
+    except ImportError as exc:
+        return f"ESMFold needs torch and transformers: {exc}"
+    if _template_mmcif_dir() is None:
+        return "Set ALPHAFOLD_DATA_DIR or TEMPLATE_MMCIF_DIR to an mmCIF directory."
+    return None
+
+
+# --------------------------------------------------------------------------- #
+#                                 helpers                                     #
+# --------------------------------------------------------------------------- #
+def _searcher(
+    cache_dir: Path, scratch_dir: Path
+) -> tuple[FoldseekTemplateSearcher, PredictedStructureCache]:
+    structures = PredictedStructureCache(
+        cache_dir=cache_dir,
+        predictor=EsmfoldStructurePredictor(
+            EsmfoldSettings(
+                model_dir=Path(os.environ["ESMFOLD_MODEL_DIR"]),
+                device=os.getenv("ESMFOLD_DEVICE", "cuda"),
+                chunk_size=(
+                    int(os.environ["ESMFOLD_CHUNK_SIZE"])
+                    if os.getenv("ESMFOLD_CHUNK_SIZE")
+                    else None
+                ),
+            )
+        ),
+    )
+    searcher = FoldseekTemplateSearcher(
+        settings=FoldseekSearchSettings(
+            database=StructureDatabaseSpec(
+                name="foldseek",
+                path=Path(os.environ["FOLDSEEK_DATABASE_PATH"]),
+                identifier=os.getenv("FOLDSEEK_DATABASE_ID", "cluster-smoke-db"),
+            ),
+            temp_dir=scratch_dir,
+            cache_dir=cache_dir,
+            threads=int(os.getenv("FOLDSEEK_THREADS", "4")),
+        ),
+        structures=structures,
+        foldseek_process=SubprocessFoldseekProcess(_foldseek_binary()),
+    )
+    return searcher, structures
+
+
+def _assert_valid_template_features(
+    case: unittest.TestCase, features: dict, query_length: int
+) -> int:
+    """Assert an AlphaFold 2 template block is well formed, and return its depth."""
+    for name in TEMPLATE_FEATURE_SPECS:
+        case.assertIn(name, features, f"missing template feature {name}")
+
+    depth = int(np.asarray(features["template_domain_names"]).shape[0])
+    case.assertGreater(depth, 0, "the structural search produced no templates")
+
+    for name, (kind, dimensions) in TEMPLATE_FEATURE_SPECS.items():
+        array = np.asarray(features[name])
+        case.assertEqual(array.ndim, dimensions, f"{name} has shape {array.shape}")
+        case.assertEqual(array.shape[0], depth, f"{name} has shape {array.shape}")
+        case.assertTrue(
+            np.issubdtype(array.dtype, kind), f"{name} has dtype {array.dtype}"
+        )
+
+    aatype = np.asarray(features["template_aatype"])
+    masks = np.asarray(features["template_all_atom_masks"])
+    positions = np.asarray(features["template_all_atom_positions"])
+    case.assertEqual(aatype.shape[1], query_length)
+    case.assertEqual(aatype.shape[2], 22)
+    case.assertEqual(masks.shape[1:], (query_length, 37))
+    case.assertEqual(positions.shape[1:], (query_length, 37, 3))
+    case.assertTrue(np.all(np.isfinite(positions)), "template positions are not finite")
+
+    for index in range(depth):
+        modelled = masks[index].sum(axis=-1) > 0
+        count = int(modelled.sum())
+        # A template that covers nothing, or claims to cover residues the query
+        # does not have, is exactly what a broken alignment offset produces.
+        case.assertGreater(count, 0, f"template {index} maps no residue at all")
+        case.assertLessEqual(count, query_length)
+        case.assertTrue(
+            np.allclose(positions[index][~modelled], 0.0),
+            f"template {index} has coordinates where nothing is modelled",
+        )
+        one_hot = aatype[index][modelled]
+        case.assertTrue(
+            np.allclose(one_hot.sum(axis=-1), 1.0),
+            f"template {index} aatype is not one-hot where it is modelled",
+        )
+    return depth
+
+
+# --------------------------------------------------------------------------- #
+#                                  tests                                      #
+# --------------------------------------------------------------------------- #
+class TestStructuralTemplates(parameterized.TestCase):
+    """ESMFold on a GPU, then Foldseek, then real AlphaFold 2 featurisation."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        reason = _skip_reason()
+        if reason:
+            raise unittest.SkipTest(reason)
+        cls.workspace = Path(tempfile.mkdtemp(prefix="structural_templates_"))
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        workspace = getattr(cls, "workspace", None)
+        if workspace and workspace.exists():
+            shutil.rmtree(workspace, ignore_errors=True)
+
+    def test_esmfold_and_foldseek_produce_valid_template_features(self):
+        """The full chain, in process, ending in an AlphaFold 2 feature block."""
+        from alphafold.data import templates
+
+        searcher, structures = _searcher(
+            cache_dir=self.workspace / "cache",
+            scratch_dir=self.workspace / "scratch",
+        )
+        output = searcher.query(f">{QUERY_NAME}\n{QUERY_SEQUENCE}\n")
+        self.assertTrue(output.strip(), "Foldseek returned no alignments")
+
+        hits = searcher.get_template_hits(output, QUERY_SEQUENCE)
+        self.assertTrue(hits, "no Foldseek hit survived parsing")
+        for hit in hits:
+            # Every hit has to name a chain the featuriser can actually open.
+            pdb_id, chain_id = templates._get_pdb_id_and_chain(hit)
+            self.assertTrue(chain_id)
+            self.assertTrue(
+                (Path(_template_mmcif_dir()) / f"{pdb_id}.cif").is_file(),
+                f"hit {hit.name} has no mmCIF file in the template directory",
+            )
+
+        featuriser = templates.HhsearchHitFeaturizer(
+            mmcif_dir=str(_template_mmcif_dir()),
+            max_template_date=MAX_TEMPLATE_DATE,
+            max_hits=20,
+            kalign_binary_path=shutil.which("kalign") or "kalign",
+            release_dates_path=None,
+            obsolete_pdbs_path=None,
+        )
+        result = featuriser.get_templates(
+            query_sequence=QUERY_SEQUENCE, hits=list(hits)
+        )
+
+        depth = _assert_valid_template_features(
+            self, dict(result.features), len(QUERY_SEQUENCE)
+        )
+        logger.info("Structural search produced %d usable template(s)", depth)
+
+        # The expensive step must not be repeated on a second query.
+        self.assertTrue(
+            structures.cached(QUERY_SEQUENCE),
+            "the predicted structure was not cached",
+        )
+
+    def test_the_feature_cli_writes_features_with_structural_templates(self):
+        """The same chain through create_individual_features.py, on the CLI."""
+        data_dir = os.getenv("ALPHAFOLD_DATA_DIR")
+        if not data_dir or not Path(data_dir).is_dir():
+            self.skipTest("Set ALPHAFOLD_DATA_DIR to run the CLI leg of this test.")
+
+        output_dir = self.workspace / "features"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        fasta = self.workspace / "query.fasta"
+        fasta.write_text(f">{QUERY_NAME}\n{QUERY_SEQUENCE}\n", encoding="utf-8")
+
+        script = Path(alphapulldown.__path__[0]) / "scripts" / "create_individual_features.py"
+        command = [
+            sys.executable,
+            str(script),
+            f"--fasta_paths={fasta}",
+            f"--data_dir={data_dir}",
+            f"--output_dir={output_dir}",
+            f"--max_template_date={MAX_TEMPLATE_DATE}",
+            # Templates are the point here; a full MSA run is not.
+            "--skip_msa",
+            "--save_msa_files=True",
+            "--use_foldseek_templates",
+            f"--foldseek_binary_path={_foldseek_binary()}",
+            f"--foldseek_database_path={os.environ['FOLDSEEK_DATABASE_PATH']}",
+            f"--foldseek_database_id={os.getenv('FOLDSEEK_DATABASE_ID', 'cluster-smoke-db')}",
+            f"--esmfold_model_dir={os.environ['ESMFOLD_MODEL_DIR']}",
+            f"--esmfold_device={os.getenv('ESMFOLD_DEVICE', 'cuda')}",
+            f"--structural_template_cache_dir={self.workspace / 'cache'}",
+        ]
+        completed = subprocess.run(command, capture_output=True, text=True)
+        if completed.returncode:
+            self.fail(
+                "create_individual_features.py failed:\n"
+                f"{completed.stdout[-4000:]}\n{completed.stderr[-4000:]}"
+            )
+
+        pickle_path = output_dir / f"{QUERY_NAME}.pkl"
+        if not pickle_path.is_file():
+            pickle_path = output_dir / f"{QUERY_NAME}.pkl.xz"
+        self.assertTrue(pickle_path.is_file(), f"no feature pickle in {output_dir}")
+
+        opener = lzma.open if pickle_path.suffix == ".xz" else open
+        with opener(pickle_path, "rb") as handle:
+            monomer = pickle.load(handle)
+        features = getattr(monomer, "feature_dict", monomer)
+        _assert_valid_template_features(self, dict(features), len(QUERY_SEQUENCE))
+
+        # The searcher's own hits file lands beside the sequence search's.
+        hits_files = list(output_dir.rglob("pdb_hits.m8"))
+        self.assertTrue(hits_files, "no pdb_hits.m8 was written")
+        self.assertTrue(hits_files[0].read_text(encoding="utf-8").strip())
+
+        metadata = sorted(output_dir.glob(f"{QUERY_NAME}_feature_metadata_*.json*"))
+        self.assertEqual(len(metadata), 1, f"expected one metadata file, got {metadata}")
+        opener = lzma.open if metadata[0].suffix == ".xz" else open
+        with opener(metadata[0], "rt", encoding="utf-8") as handle:
+            recorded = json.load(handle)
+        other = recorded.get("other", {})
+        self.assertEqual(str(other.get("use_foldseek_templates")), "True")
+        self.assertIn("foldseek_database_id", other)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/test/cluster/run_structural_templates.py
+++ b/test/cluster/run_structural_templates.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Submit the structural-template GPU smoke test to Slurm.
+
+Standalone wrapper for `test/cluster/check_structural_templates.py`, and
+intentionally not a pytest module despite the filename.
+
+The submission machinery -- collect node IDs, write one sbatch script per test,
+wait, classify the outcomes, write a summary -- already exists in
+`run_alphafold2_predictions.py` and takes a ``--test-file``. Copying it here
+would mean maintaining a third near-identical copy of it, so this wrapper only
+supplies different defaults and delegates. Every option that submitter accepts
+(``--partition``, ``--gres``, ``--constraint``, ``--time``, ``--mem``,
+``--dry-run``, ``--list``, ``-k`` ...) works here unchanged, and anything passed
+on the command line wins over the defaults below.
+
+Typical usage from a login node:
+
+    python test/cluster/run_structural_templates.py
+
+Check what would be submitted, without submitting:
+
+    python test/cluster/run_structural_templates.py --list
+
+The test itself skips unless FOLDSEEK_BINARY / FOLDSEEK_DATABASE_PATH /
+ESMFOLD_MODEL_DIR / ALPHAFOLD_DATA_DIR are set and a GPU is present; see the
+module docstring of check_structural_templates.py.
+"""
+
+from __future__ import annotations
+
+__test__ = False
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECK_FILE = REPO_ROOT / "test" / "cluster" / "check_structural_templates.py"
+SUBMITTER = REPO_ROOT / "test" / "cluster" / "run_alphafold2_predictions.py"
+
+# ESMFold's weights and activations are the memory story here; Foldseek and the
+# featuriser are comparatively small, and the smoke test folds one short chain.
+DEFAULT_OPTIONS = {
+    "--test-file": str(CHECK_FILE),
+    "--mem": "48G",
+    "--time": "04:00:00",
+    "--cpus-per-task": "8",
+}
+
+
+def _load_submitter():
+    specification = importlib.util.spec_from_file_location(
+        "alphapulldown_cluster_submitter", SUBMITTER
+    )
+    if specification is None or specification.loader is None:
+        raise SystemExit(f"Cannot load the Slurm submitter from {SUBMITTER}")
+    module = importlib.util.module_from_spec(specification)
+    # Registered before execution because the submitter defines slotted
+    # dataclasses, and dataclasses resolves their annotations through
+    # sys.modules[cls.__module__].
+    sys.modules[specification.name] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+def _with_defaults(argv: list[str]) -> list[str]:
+    """Apply the defaults the caller did not already set."""
+    arguments = list(argv)
+    for option, value in DEFAULT_OPTIONS.items():
+        already_given = any(
+            argument == option or argument.startswith(f"{option}=")
+            for argument in arguments
+        )
+        if not already_given:
+            arguments.extend([option, value])
+    return arguments
+
+
+def main() -> int:
+    if not CHECK_FILE.is_file():
+        raise SystemExit(f"Test file does not exist: {CHECK_FILE}")
+    submitter = _load_submitter()
+    sys.argv = [sys.argv[0], *_with_defaults(sys.argv[1:])]
+    return submitter.main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/functional/test_foldseek_structural_templates.py
+++ b/test/functional/test_foldseek_structural_templates.py
@@ -1,0 +1,333 @@
+"""Structural template search against a real Foldseek binary and a real database.
+
+The unit and integration tiers stub Foldseek: they pin the command line and the
+parser against canned rows. Neither can tell whether Foldseek actually accepts
+the columns AlphaPulldown asks for, or whether the numbers it really writes mean
+what the parser assumes they mean. That is what this tier is for.
+
+A wrong alignment offset is the failure worth guarding against here, because it
+does not raise -- it produces silently wrong templates. So the query is a
+*truncated* copy of a chain in the database: the self-hit must come back with the
+query starting at residue 1 and the template starting at the truncation point,
+and every aligned column is checked against both full sequences.
+
+ESMFold is not involved. Folding is stubbed with a structure taken from the test
+data, so this stays deterministic and CPU-only; the GPU chain is smoke-tested in
+``test/cluster/check_structural_templates.py``.
+
+Set ``FOLDSEEK_BINARY`` (or put ``foldseek`` on PATH) to run it.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import warnings
+
+import pytest
+
+pytestmark = [pytest.mark.functional, pytest.mark.external_tools]
+
+from alphapulldown.structural_templates import (  # noqa: E402
+    FOLDSEEK_OUTPUT_COLUMNS,
+    FoldseekSearchSettings,
+    FoldseekTemplateSearcher,
+    PredictedStructureCache,
+    StructureDatabaseSpec,
+    SubprocessFoldseekProcess,
+    parse_foldseek_alignments,
+    pdb_chain_name,
+)
+
+TEST_DATA = Path(__file__).resolve().parents[1] / "test_data"
+SOURCE_MMCIF = TEST_DATA / "templates" / "3L4Q.cif"
+OTHER_MMCIF = TEST_DATA / "templates" / "0099.cif"
+
+# The query is chain A with this many N-terminal residues removed, so the
+# self-hit's template start is not 1 and an off-by-one cannot hide.
+TRUNCATION = 10
+QUERY_CHAIN = "A"
+# A copy of the same structure under a name that is not a PDB chain. It hits, so
+# the "skipped, no mmCIF to read" path is genuinely exercised rather than assumed.
+NON_PDB_STEM = "AF-P12345-F1-model_v4"
+
+
+def _foldseek_binary() -> str:
+    binary = os.environ.get("FOLDSEEK_BINARY") or shutil.which("foldseek")
+    if not binary:
+        pytest.skip(
+            "Foldseek is not installed; set FOLDSEEK_BINARY or put foldseek on PATH"
+        )
+    if not Path(binary).is_file():
+        pytest.skip(f"FOLDSEEK_BINARY does not exist: {binary}")
+    return binary
+
+
+def _chain_residues(path: Path, chain_id: str):
+    from Bio.PDB import MMCIFParser
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        structure = MMCIFParser(QUIET=True).get_structure("query", str(path))
+    model = next(iter(structure))
+    return structure, model, [
+        residue for residue in model[chain_id] if residue.id[0] == " "
+    ]
+
+
+def _one_letter(residue) -> str:
+    from Bio.PDB.Polypeptide import index_to_one, three_to_index
+
+    try:
+        return index_to_one(three_to_index(residue.get_resname()))
+    except (KeyError, IndexError):
+        return "X"
+
+
+@pytest.fixture(scope="module")
+def foldseek_binary() -> str:
+    return _foldseek_binary()
+
+
+@pytest.fixture(scope="module")
+def chain_sequence() -> str:
+    """The full one-letter sequence of the chain the database entry contains."""
+    _, _, residues = _chain_residues(SOURCE_MMCIF, QUERY_CHAIN)
+    return "".join(_one_letter(residue) for residue in residues)
+
+
+@pytest.fixture(scope="module")
+def query(tmp_path_factory) -> tuple[str, str]:
+    """A truncated copy of the chain: its PDB text and its exact sequence."""
+    from Bio.PDB import PDBIO, Select
+
+    structure, model, residues = _chain_residues(SOURCE_MMCIF, QUERY_CHAIN)
+    keep = {residue.id for residue in residues[TRUNCATION:]}
+
+    class _Truncated(Select):
+        def accept_model(self, candidate):
+            return candidate.id == model.id
+
+        def accept_chain(self, candidate):
+            return candidate.id == QUERY_CHAIN
+
+        def accept_residue(self, candidate):
+            return candidate.id in keep
+
+    writer = PDBIO()
+    writer.set_structure(structure)
+    path = tmp_path_factory.mktemp("query") / "truncated.pdb"
+    writer.save(str(path), select=_Truncated())
+    sequence = "".join(_one_letter(residue) for residue in residues[TRUNCATION:])
+    return path.read_text(encoding="utf-8"), sequence
+
+
+@pytest.fixture(scope="module")
+def mmcif_dir(tmp_path_factory) -> Path:
+    """An mmCIF directory named the way AlphaFold 2 expects to read it."""
+    directory = tmp_path_factory.mktemp("mmcif_files")
+    shutil.copy(SOURCE_MMCIF, directory / "3l4q.cif")
+    shutil.copy(OTHER_MMCIF, directory / "0099.cif")
+    return directory
+
+
+@pytest.fixture(scope="module")
+def structure_database(foldseek_binary, tmp_path_factory, mmcif_dir) -> Path:
+    """A tiny Foldseek database built from those same mmCIF files."""
+    source = tmp_path_factory.mktemp("db_source")
+    for entry in mmcif_dir.glob("*.cif"):
+        shutil.copy(entry, source / entry.name)
+    shutil.copy(SOURCE_MMCIF, source / f"{NON_PDB_STEM}.cif")
+
+    database = tmp_path_factory.mktemp("foldseek_db") / "structures"
+    completed = subprocess.run(
+        [foldseek_binary, "createdb", str(source), str(database)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    if completed.returncode:
+        pytest.fail(f"foldseek createdb failed:\n{completed.stderr[-2000:]}")
+    return database
+
+
+@pytest.fixture(scope="module")
+def search_output(foldseek_binary, structure_database, query, tmp_path_factory) -> str:
+    """Raw Foldseek output, produced through AlphaPulldown's own searcher."""
+    structure, sequence = query
+    root = tmp_path_factory.mktemp("search")
+
+    class _RecordedStructure:
+        """Stands in for ESMFold: this tier is about Foldseek, not folding."""
+
+        def identity(self) -> str:
+            return "test-data-structure:3L4Q_A"
+
+        def predict(self, _sequence: str) -> str:
+            return structure
+
+    searcher = FoldseekTemplateSearcher(
+        settings=FoldseekSearchSettings(
+            database=StructureDatabaseSpec(
+                name="foldseek",
+                path=structure_database,
+                identifier="functional-test-db",
+            ),
+            temp_dir=root / "scratch",
+            cache_dir=root / "cache",
+            e_value=1.0,
+            max_hits=50,
+            threads=2,
+        ),
+        structures=PredictedStructureCache(
+            cache_dir=root / "cache", predictor=_RecordedStructure()
+        ),
+        foldseek_process=SubprocessFoldseekProcess(foldseek_binary),
+    )
+    return searcher.query(f">query\n{sequence}\n")
+
+
+@pytest.fixture(scope="module")
+def hits(search_output, query):
+    _, sequence = query
+    return parse_foldseek_alignments(search_output, sequence)
+
+
+def test_foldseek_accepts_every_column_alphapulldown_parses(search_output):
+    """The requested --format-output columns all exist in this Foldseek build."""
+    rows = [line for line in search_output.splitlines() if line.strip()]
+    assert rows, "the real search returned no rows at all"
+    for row in rows:
+        assert len(row.split("\t")) == len(FOLDSEEK_OUTPUT_COLUMNS), row
+
+
+def test_real_output_parses_into_usable_hits(hits):
+    assert hits, "no hit survived parsing of real Foldseek output"
+    # The database was built from the query's own structure, so it must be found.
+    assert "3l4q_A" in {hit.name for hit in hits}
+    for hit in hits:
+        assert re.fullmatch(r"[0-9a-z]{4}_[A-Za-z0-9.]+", hit.name), hit.name
+        assert hit.query_alignment and hit.hit_alignment
+        assert len(hit.query_alignment) == len(hit.hit_alignment)
+        assert hit.aligned_cols > 0
+
+
+def test_every_hit_names_an_mmcif_file_the_featuriser_can_open(hits, mmcif_dir):
+    templates = pytest.importorskip("alphafold.data.templates")
+
+    for hit in hits:
+        pdb_id, chain_id = templates._get_pdb_id_and_chain(hit.to_template_hit())
+        assert chain_id
+        assert (mmcif_dir / f"{pdb_id}.cif").is_file(), (
+            f"hit {hit.name} has no mmCIF file in the template directory"
+        )
+
+
+def test_a_target_that_is_not_a_pdb_chain_is_dropped(search_output, hits):
+    targets = [line.split("\t")[1] for line in search_output.splitlines() if line.strip()]
+    non_pdb = [target for target in targets if target.startswith(NON_PDB_STEM)]
+    assert non_pdb, (
+        "the non-PDB entry did not appear in the raw output, so this test would "
+        "not have exercised the skip path"
+    )
+    assert all(pdb_chain_name(target) is None for target in non_pdb)
+    assert not [hit for hit in hits if NON_PDB_STEM.lower() in hit.name.lower()]
+
+
+def test_alignment_offsets_place_every_residue_where_it_belongs(
+    hits, query, chain_sequence
+):
+    """The check a wrong offset would fail silently everywhere else.
+
+    The query is the database chain minus its first ``TRUNCATION`` residues, so
+    the self-hit has to start at query residue 1 and template residue
+    ``TRUNCATION + 1``. Both alignment rows are then checked residue by residue
+    against the sequences they claim to index.
+    """
+    _, sequence = query
+    self_hit = next(hit for hit in hits if hit.name == "3l4q_A")
+
+    assert self_hit.query_start == 1
+    assert self_hit.hit_start == TRUNCATION + 1
+
+    template_hit = self_hit.to_template_hit()
+    for column, (query_index, hit_index) in enumerate(
+        zip(template_hit.indices_query, template_hit.indices_hit)
+    ):
+        if query_index != -1:
+            assert sequence[query_index] == template_hit.query[column]
+        if hit_index != -1:
+            assert chain_sequence[hit_index] == template_hit.hit_sequence[column]
+
+    assert template_hit.indices_query[0] == 0
+    assert template_hit.indices_hit[0] == TRUNCATION
+
+
+def test_alphafold_maps_the_whole_query_onto_the_self_hit(hits, query):
+    templates = pytest.importorskip("alphafold.data.templates")
+    _, sequence = query
+    template_hit = next(
+        hit for hit in hits if hit.name == "3l4q_A"
+    ).to_template_hit()
+
+    mapping = templates._build_query_to_hit_index_mapping(
+        template_hit.query,
+        template_hit.hit_sequence,
+        template_hit.indices_hit,
+        template_hit.indices_query,
+        sequence,
+    )
+
+    # A gapless self-alignment: every query residue maps, in order, onto the
+    # aligned template residue at the same position.
+    assert mapping == {index: index for index in range(len(sequence))}
+
+
+def test_the_search_result_is_cached_for_the_next_run(
+    foldseek_binary, structure_database, query, tmp_path
+):
+    """A second identical query must not shell out to Foldseek again."""
+    structure, sequence = query
+    calls: list[str] = []
+
+    class _CountingFoldseek(SubprocessFoldseekProcess):
+        def search(self, query_structure, settings):
+            calls.append(str(query_structure))
+            return super().search(query_structure, settings)
+
+    def _searcher():
+        return FoldseekTemplateSearcher(
+            settings=FoldseekSearchSettings(
+                database=StructureDatabaseSpec(
+                    name="foldseek",
+                    path=structure_database,
+                    identifier="functional-test-db",
+                ),
+                temp_dir=tmp_path / "scratch",
+                cache_dir=tmp_path / "cache",
+                e_value=1.0,
+                max_hits=50,
+                threads=2,
+            ),
+            structures=PredictedStructureCache(
+                cache_dir=tmp_path / "cache",
+                predictor=type(
+                    "_Stub",
+                    (),
+                    {
+                        "identity": lambda self: "test-data-structure:3L4Q_A",
+                        "predict": lambda self, _sequence: structure,
+                    },
+                )(),
+            ),
+            foldseek_process=_CountingFoldseek(foldseek_binary),
+        )
+
+    first = _searcher().query(f">query\n{sequence}\n")
+    second = _searcher().query(f">query\n{sequence}\n")
+
+    assert first == second
+    assert len(calls) == 1

--- a/test/integration/test_foldseek_template_stack.py
+++ b/test/integration/test_foldseek_template_stack.py
@@ -1,0 +1,233 @@
+"""The Foldseek template path as the feature CLI wires it, against a stub binary.
+
+Nothing here needs a GPU, real weights, a real Foldseek build or a structure
+database: the executable is a script the test writes, and the structure predictor
+is a double. What is exercised is the wiring -- the command AlphaPulldown builds,
+the searcher AlphaFold 2 is handed, and the promise that a default run is
+untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+from alphapulldown.scripts._foldseek_cli import (  # noqa: E402
+    STRUCTURAL_TEMPLATE_FLAG_NAMES,
+)
+from alphapulldown.structural_templates import (  # noqa: E402
+    FOLDSEEK_OUTPUT_COLUMNS,
+    FoldseekSearchSettings,
+    FoldseekTemplateSearcher,
+    PredictedStructureCache,
+    StructureDatabaseSpec,
+    SubprocessFoldseekProcess,
+)
+
+QUERY = "MKTAYIAKQRQISFVKSHFSR"
+
+ALIGNMENT_ROW = "\t".join(
+    {
+        "query": "0123456789abcdef",
+        "target": "1abc.cif.gz_A",
+        "fident": "0.42",
+        "alnlen": "10",
+        "qstart": "1",
+        "qend": "10",
+        "tstart": "5",
+        "tend": "14",
+        "evalue": "1e-20",
+        "bits": "120",
+        "qaln": "MKTAYIAKQR",
+        "taln": "MKTGYIAKQR",
+        "alntmscore": "0.78",
+    }[column]
+    for column in FOLDSEEK_OUTPUT_COLUMNS
+)
+
+
+class _StubPredictor:
+    """Stands in for ESMFold; the point here is the Foldseek command."""
+
+    def identity(self) -> str:
+        return "stub-predictor:1"
+
+    def predict(self, sequence: str) -> str:
+        return f"REMARK stub structure for {len(sequence)} residues\nEND\n"
+
+
+def _stub_foldseek(tmp_path: Path, record: Path) -> Path:
+    """A fake ``foldseek`` that records its arguments and writes canned output."""
+    binary = tmp_path / "foldseek"
+    binary.write_text(
+        "\n".join(
+            [
+                f"#!{sys.executable}",
+                "import pathlib, sys",
+                "argv = sys.argv[1:]",
+                "if argv[:1] == ['version']:",
+                "    print('9.427df8a')",
+                "    raise SystemExit(0)",
+                f"pathlib.Path({str(record)!r}).write_text('\\n'.join(argv))",
+                # easy-search <query> <database> <output> <tmp>
+                f"pathlib.Path(argv[3]).write_text({ALIGNMENT_ROW + chr(10)!r})",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    return binary
+
+
+def _searcher(tmp_path: Path, binary: Path) -> FoldseekTemplateSearcher:
+    return FoldseekTemplateSearcher(
+        settings=FoldseekSearchSettings(
+            database=StructureDatabaseSpec(
+                name="foldseek",
+                path=tmp_path / "db" / "pdb",
+                identifier="pdb-2024-01",
+            ),
+            temp_dir=tmp_path / "scratch",
+            cache_dir=tmp_path / "cache",
+            e_value=1e-5,
+            max_hits=42,
+            threads=3,
+        ),
+        structures=PredictedStructureCache(
+            cache_dir=tmp_path / "cache", predictor=_StubPredictor()
+        ),
+        foldseek_process=SubprocessFoldseekProcess(binary),
+    )
+
+
+def test_the_search_command_asks_foldseek_for_the_columns_it_parses(tmp_path):
+    record = tmp_path / "argv.txt"
+    searcher = _searcher(tmp_path, _stub_foldseek(tmp_path, record))
+
+    output = searcher.query(f">query\n{QUERY}\n")
+
+    assert output.strip() == ALIGNMENT_ROW
+    argv = record.read_text(encoding="utf-8").splitlines()
+    # easy-search <query structure> <database> <output> <scratch> then flag pairs.
+    assert argv[0] == "easy-search"
+    assert argv[1].endswith(".pdb")
+    assert argv[2] == str(tmp_path / "db" / "pdb")
+    options = dict(zip(argv[5::2], argv[6::2]))
+    assert options["--format-output"] == ",".join(FOLDSEEK_OUTPUT_COLUMNS)
+    assert options["-e"] == "1e-05"
+    assert options["--max-seqs"] == "42"
+    assert options["--threads"] == "3"
+    assert options["--alignment-type"] == "2"
+
+
+def test_the_hits_reach_alphafold_in_the_form_its_featuriser_expects(tmp_path):
+    templates = pytest.importorskip("alphafold.data.templates")
+    record = tmp_path / "argv.txt"
+    searcher = _searcher(tmp_path, _stub_foldseek(tmp_path, record))
+
+    hits = searcher.get_template_hits(searcher.query(f">query\n{QUERY}\n"), QUERY)
+
+    assert [templates._get_pdb_id_and_chain(hit) for hit in hits] == [("1abc", "A")]
+
+
+def test_a_failing_foldseek_reports_its_own_error(tmp_path):
+    binary = tmp_path / "foldseek"
+    binary.write_text(
+        f"#!{sys.executable}\nimport sys\n"
+        "sys.stderr.write('Invalid database\\n')\nraise SystemExit(1)\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    searcher = _searcher(tmp_path, binary)
+
+    with pytest.raises(RuntimeError, match="Invalid database"):
+        searcher.query(f">query\n{QUERY}\n")
+
+
+# ------------------------------------------ the default path must not change
+
+@pytest.fixture()
+def feature_cli():
+    return pytest.importorskip("alphapulldown.scripts.create_individual_features")
+
+
+def _configure_template_flags(flag_values, monkeypatch, tmp_path: Path) -> None:
+    mmcif_dir = tmp_path / "mmcif"
+    mmcif_dir.mkdir(exist_ok=True)
+    (mmcif_dir / "1abc.cif").write_text("data_1abc\n", encoding="utf-8")
+    seqres = tmp_path / "pdb_seqres.txt"
+    seqres.write_text(">1abc_A\nMKT\n", encoding="utf-8")
+    for name, value in {
+        "template_mmcif_dir": str(mmcif_dir),
+        "pdb_seqres_database_path": str(seqres),
+        "max_template_date": "2024-01-01",
+        "obsolete_pdbs_path": None,
+        "output_dir": str(tmp_path / "features"),
+    }.items():
+        monkeypatch.setattr(flag_values, name, value)
+
+
+def test_the_feature_cli_leaves_the_sequence_search_alone_by_default(
+    feature_cli, tmp_flags, tmp_path, monkeypatch
+):
+    hmmsearch = pytest.importorskip("alphafold.data.tools.hmmsearch")
+    _configure_template_flags(tmp_flags, monkeypatch, tmp_path)
+
+    assert feature_cli.FLAGS["use_foldseek_templates"].default is False
+    assert tmp_flags.use_foldseek_templates is False
+    searcher, featuriser = feature_cli._create_af2_template_stack()
+
+    assert isinstance(searcher, hmmsearch.Hmmsearch)
+    assert searcher.input_format == "sto"
+    assert type(featuriser).__name__ == "HmmsearchHitFeaturizer"
+
+
+def test_the_feature_cli_swaps_in_the_structural_searcher_when_asked(
+    feature_cli, tmp_flags, tmp_path, monkeypatch
+):
+    pytest.importorskip("alphafold.data.templates")
+    _configure_template_flags(tmp_flags, monkeypatch, tmp_path)
+    monkeypatch.setattr(tmp_flags, "use_foldseek_templates", True)
+    monkeypatch.setattr(tmp_flags, "foldseek_database_path", str(tmp_path / "db"))
+    monkeypatch.setattr(tmp_flags, "foldseek_database_id", "pdb-2024-01")
+    monkeypatch.setattr(tmp_flags, "esmfold_model_dir", str(tmp_path / "weights"))
+
+    searcher, featuriser = feature_cli._create_af2_template_stack()
+
+    assert isinstance(searcher, FoldseekTemplateSearcher)
+    # Featurisation is unchanged; only the source of the hits differs.
+    assert type(featuriser).__name__ == "HhsearchHitFeaturizer"
+
+
+def test_enabling_it_without_a_database_fails_before_any_work(
+    feature_cli, tmp_flags, tmp_path, monkeypatch
+):
+    _configure_template_flags(tmp_flags, monkeypatch, tmp_path)
+    monkeypatch.setattr(tmp_flags, "use_foldseek_templates", True)
+    monkeypatch.setattr(tmp_flags, "foldseek_database_path", None)
+
+    with pytest.raises(ValueError, match="--foldseek_database_path"):
+        feature_cli.validate_data_pipeline_flags()
+
+
+def test_a_default_run_records_no_structural_template_metadata(
+    feature_cli, tmp_flags, monkeypatch
+):
+    # A Foldseek binary on PATH must not turn up in the provenance of features
+    # that were never searched with it.
+    monkeypatch.setattr(tmp_flags, "foldseek_binary_path", "/usr/local/bin/foldseek")
+
+    flag_dict = tmp_flags.flag_values_dict()
+    filtered = feature_cli.structural_template_metadata_flags(flag_dict)
+
+    assert filtered == {
+        name: value
+        for name, value in flag_dict.items()
+        if name not in STRUCTURAL_TEMPLATE_FLAG_NAMES
+    }
+    assert "foldseek_binary_path" not in filtered

--- a/test/unit/test_file_handling.py
+++ b/test/unit/test_file_handling.py
@@ -1,3 +1,5 @@
+import json
+import lzma
 from pathlib import Path
 
 import pytest
@@ -116,3 +118,31 @@ def test_parse_csv_file_clusters_multiple_templates_per_protein(tmp_path):
             "chains": ["A", "B"],
         }
     ]
+
+
+def test_write_atomic_json_publishes_readable_json(tmp_path):
+    path = tmp_path / "bundle.json"
+
+    file_handling.write_atomic_json(path, {"sequence": "ACDE", "depth": 2})
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "sequence": "ACDE",
+        "depth": 2,
+    }
+
+
+def test_write_atomic_json_compresses_when_the_suffix_asks_for_it(tmp_path):
+    path = tmp_path / "bundle.json.xz"
+
+    file_handling.write_atomic_json(path, {"sequence": "ACDE"})
+
+    with lzma.open(path, "rt", encoding="utf-8") as handle:
+        assert json.load(handle) == {"sequence": "ACDE"}
+
+
+def test_write_atomic_json_leaves_no_temporary_file_behind(tmp_path):
+    file_handling.write_atomic_json(tmp_path / "bundle.json", {"a": 1})
+    file_handling.write_atomic_json(tmp_path / "bundle.json", {"a": 2})
+
+    assert [path.name for path in tmp_path.iterdir()] == ["bundle.json"]
+    assert json.loads((tmp_path / "bundle.json").read_text()) == {"a": 2}

--- a/test/unit/test_foldseek_template_flags.py
+++ b/test/unit/test_foldseek_template_flags.py
@@ -1,0 +1,133 @@
+"""The structural-template flag schema: validation, defaults, and metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from alphapulldown.scripts._foldseek_cli import (
+    STRUCTURAL_TEMPLATE_FLAG_NAMES,
+    build_foldseek_template_searcher,
+    cache_dir,
+    foldseek_search_settings,
+    structural_template_metadata_flags,
+    validate_structural_template_flags,
+)
+from alphapulldown.structural_templates import FoldseekTemplateSearcher
+
+
+def _flags(**overrides) -> SimpleNamespace:
+    values = dict(
+        use_foldseek_templates=True,
+        foldseek_binary_path="/usr/local/bin/foldseek",
+        foldseek_database_path="/databases/foldseek/pdb",
+        foldseek_database_id="pdb-2024-01",
+        foldseek_temp_dir=None,
+        foldseek_e_value=1e-3,
+        foldseek_max_hits=100,
+        foldseek_min_alignment_tm_score=0.0,
+        foldseek_alignment_type=2,
+        foldseek_threads=8,
+        structural_template_cache_dir=None,
+        esmfold_model_dir="/weights/esmfold_v1",
+        esmfold_device="cuda",
+        esmfold_chunk_size=None,
+        esmfold_max_sequence_length=1500,
+        use_mmseqs2=False,
+        data_pipeline="alphafold2",
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+# --------------------------------------------------------------- validation
+
+def test_a_disabled_feature_needs_no_configuration():
+    validate_structural_template_flags(_flags(use_foldseek_templates=False))
+
+
+def test_enabling_without_a_database_names_every_missing_flag():
+    with pytest.raises(ValueError) as error:
+        validate_structural_template_flags(
+            _flags(foldseek_database_path=None, esmfold_model_dir=None)
+        )
+
+    message = str(error.value)
+    assert "--foldseek_database_path" in message
+    assert "--esmfold_model_dir" in message
+
+
+def test_the_remote_mmseqs2_path_has_no_template_search_to_replace():
+    with pytest.raises(ValueError, match="--use_mmseqs2"):
+        validate_structural_template_flags(_flags(use_mmseqs2=True))
+
+
+def test_alphafold3_searches_its_own_templates():
+    with pytest.raises(ValueError, match="AlphaFold 2 data pipeline"):
+        validate_structural_template_flags(_flags(data_pipeline="alphafold3"))
+
+
+# ------------------------------------------------------------------ defaults
+
+def test_the_cache_lives_under_the_output_directory_by_default():
+    assert cache_dir(_flags(), output_dir="/out") == Path(
+        "/out/structural_templates"
+    )
+
+
+def test_an_explicit_cache_directory_wins():
+    assert cache_dir(
+        _flags(structural_template_cache_dir="/scratch/templates"), output_dir="/out"
+    ) == Path("/scratch/templates")
+
+
+def test_a_cache_directory_is_required_when_there_is_no_output_directory():
+    with pytest.raises(ValueError, match="structural_template_cache_dir"):
+        cache_dir(_flags(), output_dir=None)
+
+
+def test_foldseek_scratch_defaults_beneath_the_cache():
+    settings = foldseek_search_settings(_flags(), output_dir="/out")
+
+    assert settings.temp_dir == Path("/out/structural_templates/tmp")
+    assert settings.database.identifier == "pdb-2024-01"
+    assert settings.database.path == Path("/databases/foldseek/pdb")
+
+
+def test_the_searcher_is_built_without_touching_foldseek_or_the_weights():
+    # Construction must stay cheap: nothing is run and no checkpoint is loaded
+    # until a query actually arrives.
+    searcher = build_foldseek_template_searcher(_flags(), output_dir="/out")
+
+    assert isinstance(searcher, FoldseekTemplateSearcher)
+    assert searcher.input_format == "a3m"
+
+
+# ------------------------------------------------------------------ metadata
+
+def test_metadata_omits_the_feature_entirely_when_it_is_off():
+    flag_dict = {"use_hhsearch": False, **vars(_flags(use_foldseek_templates=False))}
+
+    filtered = structural_template_metadata_flags(flag_dict)
+
+    # Exactly the structural-template flags go, so a default run's metadata is
+    # the same dict it was before this feature existed.
+    assert set(flag_dict) - set(filtered) == set(STRUCTURAL_TEMPLATE_FLAG_NAMES)
+    assert filtered["use_hhsearch"] is False
+
+
+def test_metadata_records_the_feature_when_it_is_used():
+    filtered = structural_template_metadata_flags(vars(_flags()))
+
+    assert filtered["foldseek_database_id"] == "pdb-2024-01"
+    assert filtered["use_foldseek_templates"] is True
+
+
+def test_metadata_filtering_does_not_mutate_the_caller_s_flags():
+    flag_dict = vars(_flags(use_foldseek_templates=False))
+
+    structural_template_metadata_flags(flag_dict)
+
+    assert "foldseek_database_id" in flag_dict

--- a/test/unit/test_structural_templates.py
+++ b/test/unit/test_structural_templates.py
@@ -1,0 +1,502 @@
+"""Foldseek + ESMFold structural templates: parsing, naming, caching, errors."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from alphapulldown.structural_templates import (
+    FOLDSEEK_OUTPUT_COLUMNS,
+    EsmfoldSettings,
+    EsmfoldStructurePredictor,
+    FoldseekSearchSettings,
+    FoldseekTemplateSearcher,
+    PredictedStructureCache,
+    StructuralTemplateToolMissing,
+    StructureDatabaseSpec,
+    SubprocessFoldseekProcess,
+    alignment_indices,
+    parse_foldseek_alignments,
+    pdb_chain_name,
+    query_sequence_from_a3m,
+)
+
+
+QUERY = "MKTAYIAKQRQISFVKSHFSR"
+
+STRUCTURE = "ATOM      1  N   MET A   1      0.000   0.000   0.000\nEND\n"
+
+
+def _row(**overrides) -> str:
+    fields = {
+        "query": "0123456789abcdef",
+        "target": "1abc.cif.gz_A",
+        "fident": "0.420",
+        "alnlen": "11",
+        "qstart": "1",
+        "qend": "10",
+        "tstart": "5",
+        "tend": "15",
+        "evalue": "1.230E-20",
+        "bits": "120",
+        "qaln": "MKTAY-IAKQR",
+        "taln": "MKTGYQIAKQR",
+        "alntmscore": "0.781",
+    }
+    fields.update(overrides)
+    return "\t".join(fields[column] for column in FOLDSEEK_OUTPUT_COLUMNS)
+
+
+SECOND_ROW = _row(
+    target="2xyz_B",
+    qstart="3",
+    qend="12",
+    tstart="1",
+    tend="10",
+    alnlen="10",
+    bits="60",
+    qaln="TAYIAKQRQI",
+    taln="TAWIAKQRQI",
+    alntmscore="0.351",
+)
+
+
+# ------------------------------------------------------------ target naming
+
+@pytest.mark.parametrize(
+    "target,expected",
+    [
+        ("1abc_A", "1abc_A"),
+        ("1ABC_A", "1abc_A"),
+        ("1abc.cif.gz_A", "1abc_A"),
+        ("1abc.pdb_B", "1abc_B"),
+        ("pdb1abc.ent.gz_C", "1abc_C"),
+        ("1abc-assembly1.cif.gz_A", "1abc_A"),
+        ("/databases/pdb/1abc.cif.gz_A", "1abc_A"),
+        ("1abc_AAA", "1abc_AAA"),
+        ("1abc_.", "1abc_."),
+    ],
+)
+def test_pdb_chain_name_reduces_foldseek_target_names(target, expected):
+    assert pdb_chain_name(target) == expected
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "AF-P12345-F1-model_v4.cif.gz",  # AlphaFold DB model, not a PDB chain
+        "1abc",  # no chain
+        "notapdbid.cif.gz_A",
+        "",
+    ],
+)
+def test_pdb_chain_name_refuses_targets_without_an_mmcif_to_read(target):
+    assert pdb_chain_name(target) is None
+
+
+# -------------------------------------------------------- alignment indices
+
+def test_alignment_indices_are_zero_based_and_mark_gaps():
+    indices_query, indices_hit = alignment_indices(
+        "MKTAY-IAKQR", "MKTGYQIAKQR", query_start=1, hit_start=5
+    )
+    assert indices_query == [0, 1, 2, 3, 4, -1, 5, 6, 7, 8, 9]
+    assert indices_hit == [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+
+
+def test_alignment_indices_reject_rows_of_different_length():
+    with pytest.raises(ValueError, match="differ in length"):
+        alignment_indices("MKT", "MK", query_start=1, hit_start=1)
+
+
+def test_alignment_indices_reject_zero_based_starts():
+    with pytest.raises(ValueError, match="1-based"):
+        alignment_indices("MKT", "MKT", query_start=0, hit_start=1)
+
+
+# ---------------------------------------------------------- query sequence
+
+def test_query_sequence_is_the_first_a3m_record_without_gaps():
+    a3m = ">query\nMKTAY-IAKQR\n>hit\nMKTGYQIAKQR\n"
+    assert query_sequence_from_a3m(a3m) == "MKTAYIAKQR"
+
+
+def test_query_sequence_rejects_an_alignment_without_records():
+    with pytest.raises(ValueError, match="no query sequence"):
+        query_sequence_from_a3m("")
+
+
+def test_query_sequence_rejects_a_non_protein_first_record():
+    with pytest.raises(ValueError, match="protein sequence"):
+        query_sequence_from_a3m(">query\nMKT@YI\n")
+
+
+# ------------------------------------------------------------- hit parsing
+
+def test_parse_foldseek_alignments_reads_the_requested_columns():
+    hits = parse_foldseek_alignments(f"{_row()}\n{SECOND_ROW}\n", QUERY)
+
+    assert [hit.name for hit in hits] == ["1abc_A", "2xyz_B"]
+    first = hits[0]
+    assert (first.query_start, first.hit_start) == (1, 5)
+    assert first.query_alignment == "MKTAY-IAKQR"
+    assert first.hit_alignment == "MKTGYQIAKQR"
+    # One column is a query gap, so ten columns pair two residues.
+    assert first.aligned_cols == 10
+    assert first.score == pytest.approx(120.0)
+    assert first.alignment_tm_score == pytest.approx(0.781)
+
+
+def test_parse_foldseek_alignments_skips_a_header_row():
+    header = "\t".join(FOLDSEEK_OUTPUT_COLUMNS)
+    hits = parse_foldseek_alignments(f"{header}\n{_row()}\n", QUERY)
+    assert [hit.name for hit in hits] == ["1abc_A"]
+
+
+def test_parse_foldseek_alignments_skips_targets_with_no_mmcif_file():
+    hits = parse_foldseek_alignments(
+        f"{_row(target='AF-P12345-F1-model_v4.cif.gz')}\n{SECOND_ROW}\n", QUERY
+    )
+    assert [hit.name for hit in hits] == ["2xyz_B"]
+
+
+def test_parse_foldseek_alignments_skips_rows_with_the_wrong_field_count():
+    hits = parse_foldseek_alignments(f"one\ttwo\tthree\n{_row()}\n", QUERY)
+    assert [hit.name for hit in hits] == ["1abc_A"]
+
+
+def test_parse_foldseek_alignments_skips_rows_with_unreadable_numbers():
+    hits = parse_foldseek_alignments(f"{_row(qstart='first')}\n{SECOND_ROW}\n", QUERY)
+    assert [hit.name for hit in hits] == ["2xyz_B"]
+
+
+def test_parse_foldseek_alignments_skips_alignments_that_are_not_this_query():
+    # The featuriser locates the aligned region by searching the query sequence
+    # for it, so a row belonging to another query must not reach it.
+    hits = parse_foldseek_alignments(
+        f"{_row(qaln='WWWWWWWWWWW')}\n{SECOND_ROW}\n", QUERY
+    )
+    assert [hit.name for hit in hits] == ["2xyz_B"]
+
+
+def test_parse_foldseek_alignments_skips_ragged_alignment_rows():
+    hits = parse_foldseek_alignments(f"{_row(taln='MKT')}\n{SECOND_ROW}\n", QUERY)
+    assert [hit.name for hit in hits] == ["2xyz_B"]
+
+
+def test_parse_foldseek_alignments_applies_the_tm_score_threshold():
+    output = f"{_row()}\n{SECOND_ROW}\n"
+    assert [hit.name for hit in parse_foldseek_alignments(output, QUERY)] == [
+        "1abc_A",
+        "2xyz_B",
+    ]
+    kept = parse_foldseek_alignments(output, QUERY, min_alignment_tm_score=0.5)
+    assert [hit.name for hit in kept] == ["1abc_A"]
+
+
+def test_parse_foldseek_alignments_tolerates_a_missing_tm_score():
+    hits = parse_foldseek_alignments(_row(alntmscore="nan"), QUERY)
+    assert hits[0].alignment_tm_score is None
+
+
+def test_parse_foldseek_alignments_ignores_blank_and_comment_lines():
+    hits = parse_foldseek_alignments(f"\n# a comment\n{_row()}\n\n", QUERY)
+    assert len(hits) == 1
+
+
+# ------------------------------------------------- AlphaFold 2 hit handover
+
+def test_hit_converts_to_an_alphafold_template_hit():
+    parsers = pytest.importorskip("alphafold.data.parsers")
+    hit = parse_foldseek_alignments(_row(), QUERY)[0].to_template_hit()
+
+    assert isinstance(hit, parsers.TemplateHit)
+    # AlphaFold 2 parses the PDB id and chain straight off the front of the name.
+    assert hit.name == "1abc_A"
+    assert hit.aligned_cols == 10
+    assert hit.indices_query == [0, 1, 2, 3, 4, -1, 5, 6, 7, 8, 9]
+    assert hit.indices_hit == [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+
+
+def test_converted_hit_maps_query_residues_onto_the_template():
+    templates = pytest.importorskip("alphafold.data.templates")
+    hit = parse_foldseek_alignments(_row(), QUERY)[0].to_template_hit()
+
+    mapping = templates._build_query_to_hit_index_mapping(
+        hit.query, hit.hit_sequence, hit.indices_hit, hit.indices_query, QUERY
+    )
+
+    assert mapping == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}
+
+
+def test_alphafold_can_read_the_pdb_id_and_chain_from_every_hit_name():
+    templates = pytest.importorskip("alphafold.data.templates")
+    hits = parse_foldseek_alignments(f"{_row()}\n{SECOND_ROW}\n", QUERY)
+
+    parsed = [
+        templates._get_pdb_id_and_chain(hit.to_template_hit()) for hit in hits
+    ]
+
+    assert parsed == [("1abc", "A"), ("2xyz", "B")]
+
+
+# -------------------------------------------------------------- test doubles
+
+class _FakePredictor:
+    def __init__(self, identity: str = "esmfold:test:0123456789abcdef"):
+        self._identity = identity
+        self.folded: list[str] = []
+
+    def identity(self) -> str:
+        return self._identity
+
+    def predict(self, sequence: str) -> str:
+        self.folded.append(sequence)
+        return STRUCTURE
+
+
+class _FakeFoldseek:
+    def __init__(self, output: str, identity: str = "foldseek 9.427df8a"):
+        self._output = output
+        self._identity = identity
+        self.searches: list[tuple[str, str]] = []
+
+    def identity(self) -> str:
+        return self._identity
+
+    def search(self, query_structure: Path, settings: FoldseekSearchSettings) -> str:
+        self.searches.append(
+            (Path(query_structure).name, Path(query_structure).read_text())
+        )
+        assert settings.database.identifier
+        return self._output
+
+
+def _settings(tmp_path: Path, *, identifier: str = "pdb-2024-01", **overrides):
+    defaults = dict(
+        database=StructureDatabaseSpec(
+            name="foldseek", path=tmp_path / "db", identifier=identifier
+        ),
+        temp_dir=tmp_path / "tmp",
+        cache_dir=tmp_path / "cache",
+    )
+    defaults.update(overrides)
+    return FoldseekSearchSettings(**defaults)
+
+
+def _searcher(tmp_path: Path, predictor, foldseek, **overrides):
+    return FoldseekTemplateSearcher(
+        settings=_settings(tmp_path, **overrides),
+        structures=PredictedStructureCache(
+            cache_dir=_settings(tmp_path, **overrides).cache_dir, predictor=predictor
+        ),
+        foldseek_process=foldseek,
+    )
+
+
+# ---------------------------------------------------------------- searching
+
+def test_searcher_announces_the_formats_alphafold_asks_about(tmp_path):
+    searcher = _searcher(tmp_path, _FakePredictor(), _FakeFoldseek(_row()))
+    assert searcher.input_format == "a3m"
+    assert searcher.output_format == "m8"
+
+
+def test_query_folds_the_first_a3m_record_and_returns_foldseek_output(tmp_path):
+    predictor = _FakePredictor()
+    foldseek = _FakeFoldseek(_row())
+    searcher = _searcher(tmp_path, predictor, foldseek)
+
+    output = searcher.query(f">query\n{QUERY}\n>hit\n{QUERY}\n")
+
+    assert output == _row()
+    assert predictor.folded == [QUERY]
+    name, structure = foldseek.searches[0]
+    assert name.endswith(".pdb")
+    assert structure == STRUCTURE
+
+
+def test_a_repeated_query_reuses_both_caches(tmp_path):
+    predictor = _FakePredictor()
+    foldseek = _FakeFoldseek(_row())
+    a3m = f">query\n{QUERY}\n"
+
+    first = _searcher(tmp_path, predictor, foldseek).query(a3m)
+    second = _searcher(tmp_path, predictor, foldseek).query(a3m)
+
+    assert first == second
+    assert predictor.folded == [QUERY]
+    assert len(foldseek.searches) == 1
+
+
+def test_a_rebuilt_database_invalidates_alignments_but_not_the_structure(tmp_path):
+    predictor = _FakePredictor()
+    foldseek = _FakeFoldseek(_row())
+    a3m = f">query\n{QUERY}\n"
+
+    _searcher(tmp_path, predictor, foldseek, identifier="pdb-2024-01").query(a3m)
+    _searcher(tmp_path, predictor, foldseek, identifier="pdb-2025-06").query(a3m)
+
+    assert predictor.folded == [QUERY]
+    assert len(foldseek.searches) == 2
+
+
+def test_new_weights_invalidate_the_cached_structure(tmp_path):
+    foldseek = _FakeFoldseek(_row())
+    a3m = f">query\n{QUERY}\n"
+
+    _searcher(tmp_path, _FakePredictor("esmfold:v1"), foldseek).query(a3m)
+    later = _FakePredictor("esmfold:v2")
+    _searcher(tmp_path, later, foldseek).query(a3m)
+
+    assert later.folded == [QUERY]
+    assert len(foldseek.searches) == 2
+
+
+def test_a_corrupt_cache_entry_is_replaced_rather_than_trusted(tmp_path):
+    predictor = _FakePredictor()
+    foldseek = _FakeFoldseek(_row())
+    a3m = f">query\n{QUERY}\n"
+    searcher = _searcher(tmp_path, predictor, foldseek)
+    searcher.query(a3m)
+    for entry in (tmp_path / "cache").glob("*.json"):
+        entry.write_text("{ this is not json")
+
+    assert _searcher(tmp_path, predictor, foldseek).query(a3m) == _row()
+    assert predictor.folded == [QUERY, QUERY]
+
+
+def test_alignment_provenance_records_the_database_and_the_settings(tmp_path):
+    searcher = _searcher(tmp_path, _FakePredictor(), _FakeFoldseek(_row()))
+
+    provenance = searcher.provenance()
+
+    assert provenance["database"]["identifier"] == "pdb-2024-01"
+    assert provenance["foldseek"] == "foldseek 9.427df8a"
+    assert provenance["predictor"] == "esmfold:test:0123456789abcdef"
+    assert provenance["columns"] == list(FOLDSEEK_OUTPUT_COLUMNS)
+
+
+def test_a_published_cache_entry_carries_its_provenance(tmp_path):
+    searcher = _searcher(tmp_path, _FakePredictor(), _FakeFoldseek(_row()))
+    searcher.query(f">query\n{QUERY}\n")
+
+    alignments = json.loads(
+        next((tmp_path / "cache").glob("*_foldseek.json")).read_text()
+    )
+
+    assert alignments["sequence"] == QUERY
+    assert alignments["provenance"] == searcher.provenance()
+
+
+def test_get_template_hits_returns_alphafold_hits(tmp_path):
+    pytest.importorskip("alphafold.data.parsers")
+    searcher = _searcher(tmp_path, _FakePredictor(), _FakeFoldseek(_row()))
+
+    hits = searcher.get_template_hits(_row(), QUERY)
+
+    assert [hit.name for hit in hits] == ["1abc_A"]
+
+
+# ------------------------------------------------------- structure caching
+
+def test_structure_cache_reports_whether_a_sequence_is_already_folded(tmp_path):
+    predictor = _FakePredictor()
+    cache = PredictedStructureCache(cache_dir=tmp_path / "cache", predictor=predictor)
+
+    assert cache.cached(QUERY) is False
+    cache.structure(QUERY)
+    assert cache.cached(QUERY) is True
+    assert cache.structure(QUERY) == STRUCTURE
+    assert predictor.folded == [QUERY]
+
+
+def test_structure_cache_refuses_a_non_protein_sequence(tmp_path):
+    cache = PredictedStructureCache(
+        cache_dir=tmp_path / "cache", predictor=_FakePredictor()
+    )
+    with pytest.raises(ValueError, match="protein sequence"):
+        cache.structure("MKT@YI")
+
+
+# ------------------------------------------------------- settings validation
+
+@pytest.mark.parametrize(
+    "overrides,message",
+    [
+        ({"e_value": 0.0}, "e_value"),
+        ({"max_hits": 0}, "max_hits"),
+        ({"threads": 0}, "threads"),
+        ({"min_alignment_tm_score": 1.5}, "min_alignment_tm_score"),
+        ({"alignment_type": 7}, "alignment_type"),
+    ],
+)
+def test_unusable_search_settings_are_refused(tmp_path, overrides, message):
+    with pytest.raises(ValueError, match=message):
+        FoldseekTemplateSearcher(
+            settings=_settings(tmp_path, **overrides),
+            structures=PredictedStructureCache(
+                cache_dir=tmp_path, predictor=_FakePredictor()
+            ),
+            foldseek_process=_FakeFoldseek(_row()),
+        )
+
+
+def test_a_database_without_an_identifier_is_refused(tmp_path):
+    with pytest.raises(ValueError, match="identifier"):
+        FoldseekTemplateSearcher(
+            settings=_settings(tmp_path, identifier="  "),
+            structures=PredictedStructureCache(
+                cache_dir=tmp_path, predictor=_FakePredictor()
+            ),
+            foldseek_process=_FakeFoldseek(_row()),
+        )
+
+
+# ------------------------------------------------------------ missing tools
+
+def test_an_unconfigured_foldseek_says_so_instead_of_failing_obscurely():
+    with pytest.raises(StructuralTemplateToolMissing, match="Install Foldseek"):
+        SubprocessFoldseekProcess(None).identity()
+
+
+def test_a_foldseek_path_that_does_not_exist_says_so(tmp_path):
+    process = SubprocessFoldseekProcess(tmp_path / "no-such-foldseek")
+    with pytest.raises(StructuralTemplateToolMissing, match="not found"):
+        process.identity()
+
+
+def test_missing_esmfold_weights_name_the_directory(tmp_path):
+    predictor = EsmfoldStructurePredictor(
+        EsmfoldSettings(model_dir=tmp_path / "weights", device="cpu")
+    )
+    with pytest.raises(StructuralTemplateToolMissing, match="No ESMFold weight files"):
+        predictor.identity()
+
+
+def test_esmfold_identity_witnesses_the_checkpoint_contents(tmp_path):
+    model_dir = tmp_path / "weights"
+    model_dir.mkdir()
+    (model_dir / "model.safetensors").write_bytes(b"0" * 32)
+    predictor = EsmfoldStructurePredictor(
+        EsmfoldSettings(model_dir=model_dir, device="cpu")
+    )
+
+    before = predictor.identity()
+    (model_dir / "model.safetensors").write_bytes(b"0" * 64)
+
+    assert before.startswith("esmfold:weights:")
+    assert predictor.identity() != before
+
+
+def test_esmfold_refuses_a_sequence_longer_than_the_configured_limit(tmp_path):
+    model_dir = tmp_path / "weights"
+    model_dir.mkdir()
+    (model_dir / "model.safetensors").write_bytes(b"0")
+    predictor = EsmfoldStructurePredictor(
+        EsmfoldSettings(model_dir=model_dir, device="cpu", max_sequence_length=5)
+    )
+    with pytest.raises(ValueError, match="exceeds the configured"):
+        predictor.predict("MKTAYIAKQR")


### PR DESCRIPTION
## What this adds

An **opt-in** second source of AlphaFold 2 structural templates: ESMFold predicts a structure for the query sequence, Foldseek searches that structure against a **local** structure database, and each alignment it returns becomes a `parsers.TemplateHit`.

The default path finds templates by *sequence* — a profile built from the uniref90 alignment, searched against `pdb_seqres` with hmmsearch (or PDB70 with HHsearch). That misses templates whose sequence has drifted beyond profile detection but whose fold has not, which is exactly the case where a template would help most.

Both tools run locally. There is no web API anywhere in this change.

## Only the *source* of the hits changes

Hits go to AlphaFold 2's own `HhsearchHitFeaturizer`, so:

- every template is still read from `--template_mmcif_dir` as `<pdbid>.cif`;
- `--max_template_date`, the coverage/duplicate prefilters and the 20-template cap all still apply;
- MSA generation is untouched.

Because of that, the Foldseek database must describe chains that exist in `--template_mmcif_dir` — building it from that same directory is the documented way to guarantee it. Foldseek names targets after the files it was built from (`1abc.cif.gz_A`, `pdb1abc.ent.gz_A`, `1abc-assembly1.cif.gz_A`), so those are reduced to `<pdbid>_<chain>`; a target that does not reduce to a PDB chain (an AFDB model, say) has no mmCIF to featurise from and is skipped with a warning instead of failing deep inside the featuriser.

`--keep_msas` works with it for free: an existing feature set can have only its templates replaced, structurally.

## Default off, and default behaviour is unchanged

Verified three ways:

1. **`_create_af2_template_stack()` takes its new branch only under the flag.** `test_the_feature_cli_leaves_the_sequence_search_alone_by_default` asserts the flag's declared default is `False` and that a default run still gets `hmmsearch.Hmmsearch` + `HmmsearchHitFeaturizer` with `input_format == "sto"`.
2. **Feature metadata is byte-identical.** A new absl flag would otherwise appear in `get_meta_dict`'s `other` block — and a `foldseek` binary that merely happens to be on `PATH` would be recorded as provenance for features it never touched. `structural_template_metadata_flags()` removes the new flags unless the feature was used; two tests assert `set(before) - set(after)` is *exactly* the new flag names, and that the filtered dict equals the old dict.
3. **Validation is a no-op when off.** `validate_structural_template_flags()` returns immediately unless `--use_foldseek_templates` is set.

The full suite passes locally: **508 unit** tests (a few modules skipped for optional deps missing in this environment) and **114 integration** tests, including the 84 that touch this change.

## New tests (no GPU, no weights, no real databases)

- `test/unit/test_structural_templates.py` (54) — target-name reduction, alignment-index construction, A3M query extraction, Foldseek row parsing including every drop-with-a-warning case, TM-score filtering, cache reuse and invalidation, settings validation, missing-tool errors. Three tests hand the result to real AlphaFold 2 code (`_build_query_to_hit_index_mapping`, `_get_pdb_id_and_chain`) to prove the hits are in the shape the featuriser expects.
- `test/unit/test_foldseek_template_flags.py` (12) — flag validation, defaults, metadata filtering.
- `test/integration/test_foldseek_template_stack.py` (7) — a **stub `foldseek` executable written by the test** records its argv and emits canned output, so the exact `easy-search` command line is asserted without Foldseek installed; plus the CLI wiring and the default-path guarantees. A failing stub proves Foldseek's own stderr is surfaced.
- `test/unit/test_file_handling.py` — three tests covering `write_atomic_json`, the durable-publish helper moved out of `feature_batch`.

## Caching and provenance

Two caches under `--structural_template_cache_dir`, keyed by sequence:

- `<digest>_esmfold.json` — the structure and the identity of the checkpoint that produced it;
- `<digest>_foldseek.json` — Foldseek's output plus checkpoint, Foldseek version, database identifier **and index size**, E-value, hit cap, alignment type, TM threshold and the exact columns requested.

They are separate on purpose: re-searching a refreshed database costs a Foldseek run, not a GPU run. `--foldseek_database_id` is operator-supplied and cannot notice a database rebuilt under the same name, so the index size rides along as a content-derived witness — the same reasoning as the MMseqs2 path. Raw hits are also written to `pdb_hits.m8`, beside where the sequence search writes `pdb_hits.sto` / `.hhr`.

## Missing tools produce messages, not tracebacks

No Foldseek configured, a Foldseek path that does not exist, `torch`/`transformers` not installed, no weight files in `--esmfold_model_dir`, a checkpoint that will not load, or a sequence over `--esmfold_max_sequence_length` — each raises `StructuralTemplateToolMissing` (or a `ValueError`) naming the fix. ESMFold is loaded with `local_files_only`, so a missing checkpoint is a local error rather than a silent multi-gigabyte download on a compute node.

## What a user has to install and fetch

Nothing here ships with AlphaPulldown:

- the **Foldseek** binary;
- **PyTorch + transformers** (`pip install torch transformers`);
- **ESMFold weights** in a local directory (a download of the published `facebook/esmfold_v1` checkpoint, for example);
- a **Foldseek structure database**, ideally built from the mmCIF directory AlphaPulldown already uses: `foldseek createdb <mmcif_files> <db>`.

## Refactor included

`feature_batch._write_atomic` moves to `file_handling.write_atomic_json` unchanged — the structural-template caches need the same fsync-and-rename publish, and duplicating that logic would have been the wrong trade. `feature_batch` imports it under the same private name, so no call site changed.

## Deliberately left out

- **No AlphaFold 3 integration.** AF3 runs template search inside its own data pipeline; the combination is rejected with a clear error rather than half-supported.
- **No `--use_mmseqs2` support.** That path receives MSAs and templates together from the remote server and has no separable template search to replace. Also rejected explicitly.
- **No batching across sequences.** Foldseek can search many query structures at once, but AlphaFold 2's template-searcher interface is one query at a time, so batching would mean a second entry point. The structure cache already removes the repeated cost.
- **No AFDB or other non-PDB structure databases.** They would need a featuriser that can read something other than `<pdbid>.cif`, which is a much larger change to AlphaFold 2's featurisation.
- **No changes to the AlphaPulldownSnakemake repo**, no new container image, and no Dockerfile changes — Foldseek and ESMFold are not added to any bundled image.
- **No performance measurements or claims**, deliberately.
- **`template_sum_probs` carries the Foldseek bit score** rather than an HHsearch probability. It ranks hits and is not consumed by the model; documented rather than faked.

## What a follow-up AlphaPulldownSnakemake PR would need

1. **Config keys** under a new `structural_templates:` block: `enabled` (default `false`), `foldseek_binary_path`, `foldseek_database_path`, `foldseek_database_id`, `esmfold_model_dir`, `structural_template_cache_dir`, and optionally `foldseek_e_value`, `foldseek_max_hits`, `foldseek_min_alignment_tm_score`, `foldseek_alignment_type`, `foldseek_threads`, `esmfold_device`, `esmfold_chunk_size`, `esmfold_max_sequence_length`.
2. **Flag plumbing in `create_feature_arguments`** (`rules/features.smk`): append `--use_foldseek_templates` and the flags above when `enabled`, so the existing feature rule can run it unchanged. This alone is enough to use the feature — everything below is optimisation.
3. **A new GPU rule** wrapping `predict_query_structures.py`, taking the shard's FASTA and producing the cached structures; the feature rule then depends on it and stays CPU-only. Resources: 1 GPU, roughly 24–32 GB of GPU memory for chains up to ~1500 residues, ~32 GB host RAM, and a walltime scaled to the shard size. Partitions: `gpu-el8,transform`.
4. **Feature-rule resources unchanged** when that split is used. If the split is skipped, the feature rule itself needs a GPU and the same GPU memory.
5. **Cache directory as a shared, durable path** (not per-job scratch), so structures are reused across shards and reruns — the treatment `msa_output_dir` already gets. `foldseek_temp_dir` should point at fast local scratch instead.
6. **Container/environment**: whichever image runs these rules needs the Foldseek binary and `torch`/`transformers`; the ESMFold checkpoint and the Foldseek database mount in as read-only paths alongside the AlphaFold databases.
7. **Validation at config-parse time** mirroring `validate_structural_template_flags`: enabling it without a database path/id or a checkpoint directory, or together with `use_mmseqs2` or the AF3 pipeline, should fail before any job is submitted.

## Docs

Detailed documentation lives in `docs/structural_templates.md`; `README.md` gets a single bullet pointing at it. `CONTEXT.md` gains three glossary entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
