### PR TITLE
fix: per-fold model flags, and an AF3 pipeline seam that is not a global

### DIFF
--- a/alphapulldown/af3_pipeline.py
+++ b/alphapulldown/af3_pipeline.py
@@ -1,0 +1,139 @@
+"""Building the AlphaFold 3 data pipeline from explicit settings.
+
+The batch feature scripts used to reach into ``create_individual_features`` and call
+``create_arguments()``, whose job is to *mutate the module-global FLAGS* -- filling in
+database paths from ``--data_dir`` -- and then call ``create_pipeline_af3()`` and
+``get_af3_feature_metadata()``, which read that mutation back. The interface between
+the scripts was therefore the shape of a global, and correct only if the three calls
+happened in that order.
+
+This module states the same thing as data. ``AF3PipelineSettings.from_flags`` resolves
+every path once and returns them; nothing it touches is written back. The settings also
+carry ``resolved_flag_values`` so provenance metadata can record the paths that were
+actually used without a global having been rewritten to hold them.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from typing import Any, Callable, Dict, Mapping, Optional
+
+# Binaries the AlphaFold 3 pipeline shells out to. Same name on the flags and on the
+# AlphaFold 3 config, so one tuple describes both sides.
+BINARY_FIELDS = (
+    "jackhmmer_binary_path",
+    "nhmmer_binary_path",
+    "hmmalign_binary_path",
+    "hmmsearch_binary_path",
+    "hmmbuild_binary_path",
+)
+
+# AlphaFold 3 config field -> (flag name, database key). The three names differ often
+# enough -- uniprot_cluster_annot_database_path / uniprot_database_path / uniprot -- that
+# writing them out once is what keeps a typo from silently selecting the wrong database.
+DATABASE_FIELDS: Mapping[str, tuple[str, str]] = {
+    "small_bfd_database_path": ("small_bfd_database_path", "small_bfd"),
+    "mgnify_database_path": ("mgnify_database_path", "mgnify"),
+    "uniprot_cluster_annot_database_path": ("uniprot_database_path", "uniprot"),
+    "uniref90_database_path": ("uniref90_database_path", "uniref90"),
+    "ntrna_database_path": ("ntrna_database_path", "ntrna"),
+    "rfam_database_path": ("rfam_database_path", "rfam"),
+    "rna_central_database_path": ("rna_central_database_path", "rna_central"),
+    "pdb_database_path": ("template_mmcif_dir", "template_mmcif_dir"),
+    "seqres_database_path": ("pdb_seqres_database_path", "pdb_seqres"),
+}
+
+# Number of CPUs the two search stages get. Previously inline literals.
+JACKHMMER_N_CPU = 8
+NHMMER_N_CPU = 8
+
+
+@dataclasses.dataclass(frozen=True)
+class AF3PipelineSettings:
+    """Everything the AlphaFold 3 data pipeline needs, resolved and explicit."""
+
+    max_template_date: str
+    binaries: Mapping[str, Optional[str]]
+    # Keyed by AlphaFold 3 config field.
+    databases: Mapping[str, Optional[str]]
+    # Keyed by flag name, for provenance. Same values, addressed the way metadata
+    # addresses them, so recording what was used needs no global to have been rewritten.
+    resolved_flag_values: Mapping[str, Optional[str]]
+
+    @classmethod
+    def from_flags(
+        cls,
+        flags: Any,
+        resolve_database_path: Callable[[str], Optional[str]],
+    ) -> "AF3PipelineSettings":
+        """Resolve settings from a parsed invocation without writing anything back.
+
+        ``resolve_database_path`` maps a database key to its default location under
+        ``--data_dir``; it is injected so this module does not depend on the CLI it
+        was extracted from. An explicitly given flag always wins over the default.
+        """
+        binaries = {
+            field: getattr(flags, field, None) for field in BINARY_FIELDS
+        }
+        databases: Dict[str, Optional[str]] = {}
+        resolved_flag_values: Dict[str, Optional[str]] = {}
+        for config_field, (flag_name, database_key) in DATABASE_FIELDS.items():
+            value = getattr(flags, flag_name, None) or resolve_database_path(database_key)
+            databases[config_field] = value
+            resolved_flag_values[flag_name] = value
+        return cls(
+            max_template_date=flags.max_template_date,
+            binaries=binaries,
+            databases=databases,
+            resolved_flag_values=resolved_flag_values,
+        )
+
+    def flag_values_with_resolved_paths(
+        self, flag_values: Mapping[str, Any]
+    ) -> Dict[str, Any]:
+        """``flag_values`` with the database paths this run actually used.
+
+        The explicit replacement for reading a FLAGS object that ``create_arguments``
+        had mutated on the caller's behalf.
+        """
+        return {**flag_values, **self.resolved_flag_values}
+
+
+def build_pipeline(
+    settings: AF3PipelineSettings,
+    *,
+    pipeline_cls: Any = None,
+    config_cls: Any = None,
+) -> Any:
+    """Construct the AlphaFold 3 data pipeline described by ``settings``.
+
+    The classes are parameters so this can be exercised without AlphaFold 3 installed;
+    left unset, the real ones are imported and their absence is reported the way the
+    CLI has always reported it.
+    """
+    if pipeline_cls is None or config_cls is None:
+        try:
+            from alphafold3.data.pipeline import (
+                DataPipeline as _Pipeline,
+                DataPipelineConfig as _Config,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "AlphaFold3 is not installed correctly. "
+                "Install AlphaPulldown with 'pip install -e \".[alphafold3,test]\"', "
+                "make sure the build environment provides SQLite, then build the "
+                "vendored package with 'pip install -r alphafold3/dev-requirements.txt', "
+                "'pip install --no-deps -e ./alphafold3', and 'build_data'."
+            ) from exc
+        pipeline_cls = pipeline_cls or _Pipeline
+        config_cls = config_cls or _Config
+
+    config = config_cls(
+        **settings.binaries,
+        **settings.databases,
+        jackhmmer_n_cpu=JACKHMMER_N_CPU,
+        nhmmer_n_cpu=NHMMER_N_CPU,
+        max_template_date=datetime.date.fromisoformat(settings.max_template_date),
+    )
+    return pipeline_cls(config)

--- a/alphapulldown/inference_flags.py
+++ b/alphapulldown/inference_flags.py
@@ -10,7 +10,7 @@ silence rather than reported.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Mapping
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
 
 
 # Accepted by every backend.
@@ -139,3 +139,29 @@ def validate_model_configuration(configuration: Mapping[str, Any]) -> None:
             f"Unknown model configuration key(s): {unknown}. "
             "Backends ignore keys they do not use, so this would otherwise be silent."
         )
+
+
+def group_by_model_flags(
+    jobs: Sequence[Tuple[Dict[str, Any], Dict[str, Any]]],
+) -> List[Tuple[Dict[str, Any], List[Dict[str, Any]]]]:
+    """Group ``(job, model_flags)`` pairs into one batch per distinct flag set.
+
+    ``predict_structure`` takes a single ``model_flags`` for every object it is
+    given, so objects needing different flags -- an AlphaFold 2 monomer and a
+    multimer, say -- cannot share a call. Grouping keeps like folds together while
+    letting unlike ones through, rather than applying one fold's flags to all.
+
+    Order is preserved: groups appear in the order their first job appeared, and
+    jobs keep their order within a group.
+    """
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    flags_by_key: Dict[str, Dict[str, Any]] = {}
+    for job, model_flags in jobs:
+        # Values include enums and None, so compare on a stable repr rather than
+        # requiring the flag values themselves to be hashable.
+        key = repr(sorted(model_flags.items(), key=lambda item: item[0]))
+        if key not in grouped:
+            grouped[key] = []
+            flags_by_key[key] = model_flags
+        grouped[key].append(job)
+    return [(flags_by_key[key], jobs_) for key, jobs_ in grouped.items()]

--- a/alphapulldown/scripts/create_batch_features.py
+++ b/alphapulldown/scripts/create_batch_features.py
@@ -52,9 +52,16 @@ def main(argv) -> None:
             "--use_mmseqs2, --keep_msas, --skip_msa, or --path_to_mmt"
         )
 
-    legacy_features.create_arguments()
+    # No create_arguments() here: it worked by mutating the global FLAGS and the two
+    # calls below then read that mutation back, so this stage depended on call order
+    # across a script boundary. The settings resolve the same paths explicitly.
+    settings = legacy_features.af3_pipeline_settings()
     pipeline = legacy_features.create_pipeline_af3()
-    metadata = legacy_features.get_af3_feature_metadata({"protein"}, skip_msa=True)
+    metadata = legacy_features.get_af3_feature_metadata(
+        {"protein"},
+        skip_msa=True,
+        flag_values=settings.flag_values_with_resolved_paths(FLAGS.flag_values_dict()),
+    )
     requests = _feature_requests(FLAGS.fasta_paths)
     databases = database_selection(FLAGS)
     result = FeatureBatch(

--- a/alphapulldown/scripts/create_individual_features.py
+++ b/alphapulldown/scripts/create_individual_features.py
@@ -38,6 +38,7 @@ from alphapulldown.utils.modelling_setup import create_uniprot_runner
 from alphapulldown.utils.multimeric_template_utils import (
     extract_multimeric_template_features_for_single_chain,
 )
+from alphapulldown import af3_pipeline
 from alphapulldown.utils import save_meta_data
 from alphapulldown.utils.feature_metadata import embed_metadata_in_af3_json
 from alphapulldown.utils.template_reuse import (
@@ -370,10 +371,16 @@ def filter_af3_metadata_flags(flag_dict, chain_kinds, *, skip_msa):
     return filtered
 
 
-def get_af3_feature_metadata(chain_kinds, *, skip_msa):
-    """Collect provenance for resources the AF3 pipeline actually uses."""
+def get_af3_feature_metadata(chain_kinds, *, skip_msa, flag_values=None):
+    """Collect provenance for resources the AF3 pipeline actually uses.
+
+    ``flag_values`` lets a caller pass the paths this run resolved, instead of
+    relying on ``create_arguments()`` having rewritten the global FLAGS first.
+    """
+    if flag_values is None:
+        flag_values = FLAGS.flag_values_dict()
     metadata_flags = filter_af3_metadata_flags(
-        FLAGS.flag_values_dict(), chain_kinds, skip_msa=skip_msa
+        flag_values, chain_kinds, skip_msa=skip_msa
     )
     metadata = save_meta_data.get_meta_dict(metadata_flags)
     try:
@@ -765,10 +772,14 @@ def create_custom_db(temp_dir, protein, template_paths, chains):
 
 # =================== AlphaFold 3 Feature Creation ===================
 
+def af3_pipeline_settings():
+    """Resolve the AlphaFold 3 pipeline settings from FLAGS, mutating nothing."""
+    validate_data_pipeline_flags()
+    return af3_pipeline.AF3PipelineSettings.from_flags(FLAGS, get_database_path)
+
+
 def create_pipeline_af3():
     """Create the AlphaFold3 pipeline. Raises if AF3 not available."""
-    validate_data_pipeline_flags()
-
     if AF3DataPipeline is None or AF3DataPipelineConfig is None:
         raise ImportError(
             "AlphaFold3 is not installed correctly. "
@@ -777,34 +788,11 @@ def create_pipeline_af3():
             "vendored package with 'pip install -r alphafold3/dev-requirements.txt', "
             "'pip install --no-deps -e ./alphafold3', and 'build_data'."
         ) from AF3_IMPORT_ERROR
-    
-    # Convert max_template_date string to datetime.date object
-    import datetime
-    max_template_date = datetime.date.fromisoformat(FLAGS.max_template_date)
-    def _ovr(attr, key):
-        v = getattr(FLAGS, attr, None)
-        return v or get_database_path(key)
-    
-    config = AF3DataPipelineConfig(
-        jackhmmer_binary_path=FLAGS.jackhmmer_binary_path,
-        nhmmer_binary_path=FLAGS.nhmmer_binary_path,
-        hmmalign_binary_path=FLAGS.hmmalign_binary_path,
-        hmmsearch_binary_path=FLAGS.hmmsearch_binary_path,
-        hmmbuild_binary_path=FLAGS.hmmbuild_binary_path,
-        small_bfd_database_path=_ovr("small_bfd_database_path", "small_bfd"),
-        mgnify_database_path=_ovr("mgnify_database_path", "mgnify"),
-        uniprot_cluster_annot_database_path=_ovr("uniprot_database_path", "uniprot"),
-        uniref90_database_path=_ovr("uniref90_database_path", "uniref90"),
-        ntrna_database_path=_ovr("ntrna_database_path", "ntrna"),
-        rfam_database_path=_ovr("rfam_database_path", "rfam"),
-        rna_central_database_path=_ovr("rna_central_database_path", "rna_central"),
-        pdb_database_path=_ovr("template_mmcif_dir", "template_mmcif_dir"),
-        seqres_database_path=_ovr("pdb_seqres_database_path", "pdb_seqres"),
-        jackhmmer_n_cpu=8,
-        nhmmer_n_cpu=8,
-        max_template_date=max_template_date
+    return af3_pipeline.build_pipeline(
+        af3_pipeline_settings(),
+        pipeline_cls=AF3DataPipeline,
+        config_cls=AF3DataPipelineConfig,
     )
-    return AF3DataPipeline(config)
 
 def _af3_chain_without_templates(chain):
     """Copy a protein chain keeping its MSAs but clearing its templates.

--- a/alphapulldown/scripts/finalize_batch_features.py
+++ b/alphapulldown/scripts/finalize_batch_features.py
@@ -40,9 +40,16 @@ def main(argv) -> None:
             "--skip_msa, --path_to_mmt, or --use_mmseqs2"
         )
 
-    legacy_features.create_arguments()
+    # No create_arguments() here: it worked by mutating the global FLAGS and the two
+    # calls below then read that mutation back, so this stage depended on call order
+    # across a script boundary. The settings resolve the same paths explicitly.
+    settings = legacy_features.af3_pipeline_settings()
     pipeline = legacy_features.create_pipeline_af3()
-    metadata = legacy_features.get_af3_feature_metadata({"protein"}, skip_msa=True)
+    metadata = legacy_features.get_af3_feature_metadata(
+        {"protein"},
+        skip_msa=True,
+        flag_values=settings.flag_values_with_resolved_paths(FLAGS.flag_values_dict()),
+    )
     requests = protein_requests_from_fastas(FLAGS.fasta_paths)
     result = FeatureFinalizer(
         settings=FeatureFinalizationSettings(

--- a/alphapulldown/scripts/run_structure_prediction.py
+++ b/alphapulldown/scripts/run_structure_prediction.py
@@ -14,7 +14,7 @@ gpus = jax.local_devices(backend='gpu')
 from absl import flags, app
 import os
 from os import makedirs
-from typing import Dict, List, Union, Tuple
+from typing import Any, Dict, List, Union, Tuple
 from os.path import join, basename
 from absl import logging
 import glob
@@ -340,11 +340,12 @@ def main(argv):
 
     default_postprocess_flags = inference_flags.postprocess_flags(FLAGS)
 
-    # Prepare the list of jobs
-    objects_to_model = []
-    final_model_flags = default_model_flags
-    final_postprocess_flags = default_postprocess_flags
-    
+    # Prepare the list of jobs, each carrying the model flags it needs. Deciding the
+    # flags inside the loop below and reading them after it applied the LAST fold's
+    # flags to every object, so a monomer queued behind a multimer was predicted with
+    # model_name "multimer". Postprocess flags do not vary by object.
+    jobs: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+
     for interactors, out_dir in zip(all_interactors, out_dirs):
         if not interactors:
             continue
@@ -365,20 +366,20 @@ def main(argv):
             obj, real_out = pre_modelling_setup(
                 prot_objs, output_dir=out_dir
             )
-            objects_to_model.append({'object': obj, 'output_dir': real_out})
             json_output_dir = real_out
-            
-            # Update final flags based on object type
-            final_model_flags = default_model_flags.copy()
-            final_postprocess_flags = default_postprocess_flags.copy()
-            
+
+            # Flags for THIS object, not for whichever fold happens to come last.
+            object_model_flags = default_model_flags.copy()
             if isinstance(obj, MultimericObject):
-                final_model_flags.update({
+                object_model_flags.update({
                     "model_name": "multimer",
                     "msa_depth_scan": FLAGS.msa_depth_scan,
                     "model_names_custom": FLAGS.model_names,
                     "msa_depth": FLAGS.msa_depth
                 })
+            jobs.append(
+                ({'object': obj, 'output_dir': real_out}, object_model_flags)
+            )
         elif len(json_dicts) > 1:
             json_output_dir = resolve_af3_combined_json_output_dir(
                 json_dicts,
@@ -397,15 +398,21 @@ def main(argv):
                     use_ap_style=FLAGS.use_ap_style,
                     shared_output_root=shared_output_root,
                 )
-            objects_to_model.append(
-                {'object': json_dict, 'output_dir': current_json_output_dir}
-            )
+            # An AlphaFold 3 JSON input is not an AlphaFold 2 multimer, so it takes the
+            # defaults rather than inheriting a neighbouring fold's multimer flags.
+            jobs.append((
+                {'object': json_dict, 'output_dir': current_json_output_dir},
+                default_model_flags,
+            ))
 
-    if objects_to_model:
+    # One call per distinct model-flag set. Objects that need the same flags still
+    # share a call, so a batch of like folds is unchanged; objects that need
+    # different flags are no longer forced to share the last fold's.
+    for model_flags, grouped in inference_flags.group_by_model_flags(jobs):
         predict_structure(
-            objects_to_model=objects_to_model,
-            model_flags=final_model_flags,
-            postprocess_flags=final_postprocess_flags,
+            objects_to_model=grouped,
+            model_flags=model_flags,
+            postprocess_flags=default_postprocess_flags,
             fold_backend=FLAGS.fold_backend
         )
 

--- a/test/unit/test_af3_pipeline_settings.py
+++ b/test/unit/test_af3_pipeline_settings.py
@@ -1,0 +1,104 @@
+"""AF3 pipeline settings are resolved explicitly, not by rewriting a global.
+
+The batch scripts used to call `create_arguments()` -- whose job is to mutate the
+module-global FLAGS -- and then call two functions that read that mutation back.
+The interface between the scripts was the shape of a global, and it was only
+correct if the three calls happened in that order.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from alphapulldown.af3_pipeline import (
+    BINARY_FIELDS,
+    DATABASE_FIELDS,
+    AF3PipelineSettings,
+    build_pipeline,
+)
+
+
+class _Flags:
+    """Just enough of a parsed invocation, with nothing resolved."""
+
+    def __init__(self, **overrides):
+        self.max_template_date = "2050-01-01"
+        for field in BINARY_FIELDS:
+            setattr(self, field, f"/usr/bin/{field}")
+        for _flag_name, _key in DATABASE_FIELDS.values():
+            setattr(self, _flag_name, None)
+        for key, value in overrides.items():
+            setattr(self, key, value)
+
+    def flag_values_dict(self):
+        return {k: v for k, v in vars(self).items()}
+
+
+def _resolver(key):
+    return f"/db/{key}"
+
+
+def test_settings_resolve_every_database_without_touching_the_flags():
+    flags = _Flags()
+
+    settings = AF3PipelineSettings.from_flags(flags, _resolver)
+
+    assert set(settings.databases) == set(DATABASE_FIELDS)
+    assert settings.databases["uniref90_database_path"] == "/db/uniref90"
+    # The uniprot triple is the one whose three names all differ.
+    assert settings.databases["uniprot_cluster_annot_database_path"] == "/db/uniprot"
+    # Nothing was written back.
+    for flag_name, _key in DATABASE_FIELDS.values():
+        assert getattr(flags, flag_name) is None
+
+
+def test_an_explicit_path_wins_over_the_default():
+    flags = _Flags(uniref90_database_path="/mine/uniref90.fa")
+
+    settings = AF3PipelineSettings.from_flags(flags, _resolver)
+
+    assert settings.databases["uniref90_database_path"] == "/mine/uniref90.fa"
+
+
+def test_metadata_sees_the_paths_the_run_actually_used():
+    """Provenance used to come from FLAGS *after* create_arguments() rewrote it."""
+    flags = _Flags()
+
+    settings = AF3PipelineSettings.from_flags(flags, _resolver)
+    merged = settings.flag_values_with_resolved_paths(flags.flag_values_dict())
+
+    assert merged["uniref90_database_path"] == "/db/uniref90"
+    assert merged["template_mmcif_dir"] == "/db/template_mmcif_dir"
+    # The unrelated keys survive.
+    assert merged["max_template_date"] == "2050-01-01"
+
+
+def test_settings_are_frozen_so_they_cannot_drift_after_resolution():
+    settings = AF3PipelineSettings.from_flags(_Flags(), _resolver)
+
+    try:
+        settings.max_template_date = "1999-01-01"
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("settings must be frozen")
+
+
+def test_build_pipeline_passes_binaries_databases_and_date_through():
+    captured = {}
+
+    class _Config:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    class _Pipeline:
+        def __init__(self, config):
+            self.config = config
+
+    settings = AF3PipelineSettings.from_flags(_Flags(), _resolver)
+    pipeline = build_pipeline(settings, pipeline_cls=_Pipeline, config_cls=_Config)
+
+    assert isinstance(pipeline, _Pipeline)
+    assert captured["uniref90_database_path"] == "/db/uniref90"
+    assert captured["jackhmmer_binary_path"] == "/usr/bin/jackhmmer_binary_path"
+    assert captured["max_template_date"].isoformat() == "2050-01-01"
+    assert captured["jackhmmer_n_cpu"] == 8

--- a/test/unit/test_model_flag_grouping.py
+++ b/test/unit/test_model_flag_grouping.py
@@ -1,0 +1,63 @@
+"""Model flags must follow the object, not whichever fold came last.
+
+`run_structure_prediction.main()` decided the flag set inside its loop over folds
+and read it after the loop, so every object was predicted with the LAST fold's
+flags. Queue a monomer behind a multimer and the monomer was predicted with
+model_name "multimer". It did not raise -- it silently predicted the wrong thing,
+which is the same failure `fold_preparation.py` was extracted to fix.
+"""
+
+from __future__ import annotations
+
+from alphapulldown.inference_flags import group_by_model_flags
+
+
+def _job(name):
+    return {"object": name, "output_dir": f"/out/{name}"}
+
+
+def test_a_monomer_behind_a_multimer_keeps_its_own_flags():
+    monomer = {"model_name": "monomer_ptm"}
+    multimer = {"model_name": "multimer", "msa_depth": None}
+
+    groups = group_by_model_flags(
+        [(_job("multi"), multimer), (_job("mono"), monomer)]
+    )
+
+    by_model = {flags["model_name"]: [j["object"] for j in jobs] for flags, jobs in groups}
+    assert by_model == {"multimer": ["multi"], "monomer_ptm": ["mono"]}
+
+
+def test_like_folds_still_share_one_call():
+    """Grouping must not split a homogeneous batch into one call per fold."""
+    flags = {"model_name": "monomer_ptm"}
+
+    groups = group_by_model_flags([(_job("a"), flags), (_job("b"), flags), (_job("c"), flags)])
+
+    assert len(groups) == 1
+    assert [j["object"] for _, jobs in groups for j in jobs] == ["a", "b", "c"]
+
+
+def test_order_is_preserved_within_and_between_groups():
+    a = {"model_name": "monomer_ptm"}
+    b = {"model_name": "multimer"}
+
+    groups = group_by_model_flags(
+        [(_job("a1"), a), (_job("b1"), b), (_job("a2"), a), (_job("b2"), b)]
+    )
+
+    assert [flags["model_name"] for flags, _ in groups] == ["monomer_ptm", "multimer"]
+    assert [[j["object"] for j in jobs] for _, jobs in groups] == [["a1", "a2"], ["b1", "b2"]]
+
+
+def test_unhashable_flag_values_do_not_break_grouping():
+    """Flag values include lists and None; grouping must not require hashability."""
+    flags = {"model_name": "multimer", "model_names_custom": ["model_2_multimer_v3"]}
+
+    groups = group_by_model_flags([(_job("a"), flags), (_job("b"), dict(flags))])
+
+    assert len(groups) == 1
+
+
+def test_no_jobs_means_no_calls():
+    assert group_by_model_flags([]) == []

--- a/test/unit/test_script_entrypoints.py
+++ b/test/unit/test_script_entrypoints.py
@@ -1008,14 +1008,23 @@ def test_main_routes_protein_and_json_jobs_to_predict_structure(
 
     run_structure_prediction_module.main([])
 
-    assert len(captured_calls) == 1
-    call = captured_calls[0]
-    assert call["fold_backend"] == "alphafold3"
-    assert call["objects_to_model"] == [
+    # Two calls, not one. This used to assert a single call in which the AlphaFold 3
+    # JSON input inherited model_name "multimer" from the protein fold beside it --
+    # the last-fold-wins bug, pinned as an expectation. The multimer keeps its own
+    # flags; the JSON input takes the defaults.
+    assert len(captured_calls) == 2
+    assert {call["fold_backend"] for call in captured_calls} == {"alphafold3"}
+
+    multimer_call, json_call = captured_calls
+    assert multimer_call["objects_to_model"] == [
         {"object": multimer_obj, "output_dir": f"{tmp_path / 'shared-output'}/protein"},
+    ]
+    assert multimer_call["model_flags"]["model_name"] == "multimer"
+
+    assert json_call["objects_to_model"] == [
         {"object": {"json_input": "/tmp/job.json"}, "output_dir": f"{tmp_path / 'shared-output'}/json"},
     ]
-    assert call["model_flags"]["model_name"] == "multimer"
+    assert json_call["model_flags"]["model_name"] != "multimer"
 
 
 def test_main_sets_multimer_model_flags_for_multimer_jobs(


### PR DESCRIPTION
Two findings from an architecture review of the recently merged batch work. Both are in already-merged code, not in #638 or #639.

## 1. Model flags followed the last fold, not the object (a correctness bug)

`run_structure_prediction.main()` decided `final_model_flags` **inside** its loop over folds and read it **after** the loop, so one flag set — whichever the last fold with protein objects produced — was applied to every object.

Queue a monomer behind a multimer and the monomer was predicted with `model_name: "multimer"`. Nothing raised; it silently predicted the wrong thing.

This is the same failure `fold_preparation.py` was extracted to fix, where metadata was reassigned inside a loop and read outside it. That instance was found and fixed; this sibling survived because the batch path computes flags per job and only this copy did not.

Each job now carries the flags it needs, and `inference_flags.group_by_model_flags` batches jobs by flag set — so like folds still share a single `predict_structure` call and unlike folds are no longer forced to.

**A test changed rather than being preserved.** `test_main_routes_protein_and_json_jobs_to_predict_structure` asserted one call in which an AlphaFold 3 JSON input inherited `model_name: "multimer"` from the protein fold beside it. That expectation *was* the bug.

## 2. The batch scripts' interface to the CLI was a global

`create_batch_features.py` and `finalize_batch_features.py` both called `legacy_features.create_arguments()` — whose job is to mutate module-global `FLAGS` with resolved database paths — and then called `create_pipeline_af3()` and `get_af3_feature_metadata()`, which read that mutation back. A wide, ordering-dependent, implicit interface across a script boundary.

`alphapulldown/af3_pipeline.py` states it as data instead. `AF3PipelineSettings.from_flags` resolves every binary and database path once and writes nothing back; it also carries `resolved_flag_values`, so provenance metadata records the paths actually used without a global having been rewritten to hold them. The path resolver is injected, so the new module does not depend on the CLI it came out of.

Backwards compatible: `create_pipeline_af3()` keeps its signature and its ImportError; `get_af3_feature_metadata()` gains an optional `flag_values`. Neither batch script calls `create_arguments()` any more.

## Deliberately not included

Unifying `run_structure_prediction_batch.py` with `main()`. The two carry near-identical bodies, but they have already diverged in ways that need a decision rather than a merge — `main()` supports `shared_output_root=True` and the batch adapter hardcodes `False`. Folding them together would silently pick a winner for real prediction behaviour.

`create_batch_features.py` was also flagged as having no Snakemake consumer, but it is documented in the wiki and in `workflows/mmseqs2-gpu.md` as the supported one-process mode. Having no scheduler consumer is the design, so it stays.

## Tests

564 passed, 7 skipped, 0 failed. New: `test_model_flag_grouping.py` (5) and `test_af3_pipeline_settings.py` (5), both free of heavy dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)