### PR TITLE
fix: keep AF2 chain IDs at A, B, C under padding and out-of-order asym_id

### DIFF
--- a/alphapulldown/folding_backend/alphafold2_backend.py
+++ b/alphapulldown/folding_backend/alphafold2_backend.py
@@ -247,6 +247,10 @@ def _normalize_asym_id(feature_dict: Dict, fallback_feature_dict: Dict = None) -
     these values can change across model seeds. ``protein.to_pdb`` interprets those
     integers directly as chain indices, so we remap unique IDs to ``0..N-1`` in
     first-appearance order to keep chain IDs stable (A, B, C, ...).
+
+    ``pad_input_features`` zero-pads ``asym_id`` to the batch-wide residue bound.
+    Those trailing zeros are padding rather than a chain, so they rank after every
+    real chain instead of displacing them.
     """
     asym_id = feature_dict.get("asym_id")
     if asym_id is None and fallback_feature_dict is not None:
@@ -256,16 +260,24 @@ def _normalize_asym_id(feature_dict: Dict, fallback_feature_dict: Dict = None) -
 
     asym_id = np.asarray(asym_id).reshape(-1)
 
-    # Handle both 1-based and 0-based encodings safely.
-    if asym_id.size and asym_id.min() == 1:
-        asym_id = asym_id - 1
+    # AlphaFold numbers multimer chains from 1, so a genuinely 0-based encoding
+    # starts at 0 rather than ending there.
+    padding_mask = np.zeros(asym_id.shape, dtype=bool)
+    if asym_id.size and asym_id[0] != 0:
+        non_padding = np.flatnonzero(asym_id != 0)
+        padding_mask[(non_padding[-1] + 1) if non_padding.size else 0:] = True
 
     # Deterministic contiguous remapping in first-appearance order.
-    _, first_indices, inverse_indices = np.unique(
-        asym_id, return_index=True, return_inverse=True
+    unique_ids, first_indices, inverse_indices = np.unique(
+        asym_id[~padding_mask], return_index=True, return_inverse=True
     )
     appearance_order = np.argsort(first_indices)
-    remapped_indices = appearance_order[inverse_indices].astype(np.int32)
+    ranks = np.empty_like(appearance_order)
+    ranks[appearance_order] = np.arange(appearance_order.size)
+
+    remapped_indices = np.empty(asym_id.shape, dtype=np.int32)
+    remapped_indices[~padding_mask] = ranks[inverse_indices.reshape(-1)]
+    remapped_indices[padding_mask] = unique_ids.size
 
     normalized_feature_dict = dict(feature_dict)
     normalized_feature_dict["asym_id"] = remapped_indices

--- a/test/unit/test_alphafold2_backend_helpers.py
+++ b/test/unit/test_alphafold2_backend_helpers.py
@@ -370,6 +370,60 @@ def test_resolve_gpu_relax_falls_back_when_cuda_is_missing(
     assert "falling back to CPU relax" in caplog.text
 
 
+# alphafold.common.protein.PDB_CHAIN_IDS, which to_pdb indexes with chain_index.
+PDB_CHAIN_IDS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def _chain_letters(chain_index):
+    return [PDB_CHAIN_IDS[int(i)] for i in np.asarray(chain_index)]
+
+
+def test_normalize_asym_id_is_stable_across_models_sharing_one_feature_dict(
+    af2_backend_module,
+):
+    # In multimer mode process_features returns the same dict for every model, so
+    # normalizing must neither mutate it nor drift across the five calls.
+    feature_dict = {"asym_id": np.array([1, 1, 1, 2, 2], dtype=np.int32)}
+    original = feature_dict["asym_id"].copy()
+
+    for _ in range(5):
+        normalized = af2_backend_module._normalize_asym_id(
+            feature_dict, fallback_feature_dict=feature_dict
+        )
+        assert _chain_letters(normalized["asym_id"]) == ["A", "A", "A", "B", "B"]
+
+    np.testing.assert_array_equal(feature_dict["asym_id"], original)
+
+
+def test_normalize_asym_id_ranks_padding_after_real_chains(af2_backend_module):
+    # pad_input_features zero-pads asym_id to the batch-wide residue bound.
+    padded = np.concatenate(
+        [np.ones(3, dtype=np.int32), np.full(2, 2, dtype=np.int32), np.zeros(4, np.int32)]
+    )
+
+    normalized = af2_backend_module._normalize_asym_id({"asym_id": padded})
+
+    assert _chain_letters(normalized["asym_id"]) == list("AAABBCCCC")
+
+
+def test_normalize_asym_id_keeps_zero_based_encodings(af2_backend_module):
+    normalized = af2_backend_module._normalize_asym_id(
+        {"asym_id": np.array([0, 0, 1, 1], dtype=np.int32)}
+    )
+
+    assert _chain_letters(normalized["asym_id"]) == list("AABB")
+
+
+def test_normalize_asym_id_ranks_out_of_order_chains_by_first_appearance(
+    af2_backend_module,
+):
+    out_of_order = np.array([3, 3, 1, 1, 2, 2], dtype=np.int32)
+
+    normalized = af2_backend_module._normalize_asym_id({"asym_id": out_of_order})
+
+    assert _chain_letters(normalized["asym_id"]) == list("AABBCC")
+
+
 def test_asym_query_and_msa_debug_helpers(af2_backend_module, tmp_path):
     normalized = af2_backend_module._normalize_asym_id(
         {"asym_id": np.array([5, 5, 2, 9], dtype=np.int32)}


### PR DESCRIPTION
Two chain-labelling bugs in `_normalize_asym_id`, both in the AF2 `asym_id` → `Protein.chain_index` handoff that feeds `protein.to_pdb`.

**Ranking used the wrong permutation.** `appearance_order[inverse_indices]` applies the first-appearance ordering instead of its inverse. Three or more chains whose `asym_id` are not already in first-appearance order come out shuffled — `3,1,2` produced `B, C, A`.

**Batch padding outranked the real chains.** `pad_input_features` zero-pads `asym_id` to the batch-wide residue bound, so `--desired_num_res` runs reach the remap as `[1…1, 2…2, 0…0]`. The padding then took rank 0 and a dimer came out labelled `C` and `A`. Trailing zeros are now treated as padding and ranked after every real chain; a leading zero still reads as a genuine 0-based encoding.

Verified against the real `pad_input_features` inside `alphafold2_2.5.0.sif`: a padded dimer goes from `C`/`A` to `A`/`B`.

Four regression tests in `test/unit/test_alphafold2_backend_helpers.py`. The two covering these bugs fail before the change; the other two pin behaviour that already worked — stability across the five models that share one feature dict in multimer mode, and 0-based encodings. `test/unit` is 500 passed, 11 skipped (`test_diagnostics.py` fails to collect on main too, missing `af2plots`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)